### PR TITLE
ci: update to main branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,9 +4,9 @@ name: Check Set-Up & Build
 on:
   # Triggers the workflow on push or pull request events but only for the tellor branch
   push:
-    branches: [ tellor ]
+    branches: [ main ]
   pull_request:
-    branches: [ tellor ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ name: Run Tests
 on:
   # Triggers the workflow on push or pull request events but only for the tellor branch
   push:
-    branches: [ tellor ]
+    branches: [ main ]
   pull_request:
-    branches: [ tellor ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tellor
 
-[![Check Set-Up & Build](https://github.com/evilrobot-01/substrate-pallets/actions/workflows/check.yml/badge.svg?branch=tellor)](https://github.com/evilrobot-01/substrate-pallets/actions/workflows/check.yml)
-[![Run Tests](https://github.com/evilrobot-01/substrate-pallets/actions/workflows/test.yml/badge.svg?branch=tellor)](https://github.com/evilrobot-01/substrate-pallets/actions/workflows/test.yml)
+[![Check Set-Up & Build](https://github.com/tellor-io/tellor-pallet/actions/workflows/check.yml/badge.svg?branch=main)](https://github.com/tellor-io/tellor-pallet/actions/workflows/check.yml)
+[![Run Tests](https://github.com/tellor-io/tellor-pallet/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/tellor-io/tellor-pallet/actions/workflows/test.yml)
 
 License: Unlicense
 


### PR DESCRIPTION
Updates the GH workflows to use the `main` branch, along with badges within readme.