### PR TITLE
refactor: standardise on dispute_id hash

### DIFF
--- a/runtime-api/src/autopay.rs
+++ b/runtime-api/src/autopay.rs
@@ -3,9 +3,9 @@ use sp_std::vec::Vec;
 use tellor::FeedDetails;
 
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
-pub struct FeedDetailsWithQueryData<Amount, Timestamp> {
+pub struct FeedDetailsWithQueryData<Amount> {
 	/// Feed details for feed identifier with funding.
-	pub details: FeedDetails<Amount, Timestamp>,
+	pub details: FeedDetails<Amount>,
 	/// Query data for requested data
 	pub query_data: Vec<u8>,
 }

--- a/runtime-api/src/governance.rs
+++ b/runtime-api/src/governance.rs
@@ -2,7 +2,7 @@ use codec::{Decode, Encode};
 
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
 pub struct VoteInfo<Amount, BlockNumber, Timestamp> {
-	pub vote_round: u32,
+	pub vote_round: u8,
 	pub start_date: Timestamp,
 	pub block_number: BlockNumber,
 	pub fee: Amount,

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -275,7 +275,7 @@ sp_api::decl_runtime_apis! {
 		/// * `voter` - The account of the voter to check.
 		/// # Returns
 		/// Whether or not the account voted for the specific dispute round.
-		fn did_vote(dispute_id: DisputeId, vote_round: u32, voter: AccountId) -> bool;
+		fn did_vote(dispute_id: DisputeId, vote_round: u8, voter: AccountId) -> bool;
 
 		/// Get the latest dispute fee.
 		/// # Returns
@@ -317,14 +317,14 @@ sp_api::decl_runtime_apis! {
 		/// # Returns
 		/// Information on a vote for a given dispute identifier including: the vote identifier, the
 		/// vote information, whether it has been executed, the vote result and the dispute initiator.
-		fn get_vote_info(dispute_id: DisputeId, vote_round: u32) -> Option<(VoteInfo<Amount,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)>;
+		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<Amount,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)>;
 
 		/// Returns the voting rounds for a given dispute identifier.
 		/// # Arguments
 		/// * `dispute_id` - Identifier for a dispute.
 		/// # Returns
 		/// The number of vote rounds for the dispute identifier.
-		fn get_vote_rounds(dispute_id: DisputeId) -> u32;
+		fn get_vote_rounds(dispute_id: DisputeId) -> u8;
 
 		/// Returns the total number of votes cast by a voter.
 		/// # Arguments

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -6,7 +6,7 @@ pub use autopay::{FeedDetailsWithQueryData, SingleTipWithQueryData};
 use codec::Codec;
 pub use governance::VoteInfo;
 use sp_std::vec::Vec;
-use tellor::{FeedDetails, Tip, VoteResult};
+use tellor::{DisputeId, FeedDetails, FeedId, QueryId, Timestamp, Tip, VoteResult};
 
 mod autopay;
 mod governance;
@@ -14,7 +14,7 @@ mod governance;
 mod tests;
 
 sp_api::decl_runtime_apis! {
-	pub trait TellorAutoPay<AccountId: Codec, Amount: Codec, FeedId: Codec, QueryId: Codec, Timestamp: Codec>
+	pub trait TellorAutoPay<AccountId: Codec, Amount: Codec>
 	{
 		/// Read current data feeds.
 		/// # Arguments
@@ -35,12 +35,12 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Unique feed identifier of parameters.
 		/// # Returns
 		/// Details of the specified feed.
-		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails<Amount, Timestamp>>;
+		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails<Amount>>;
 
 		/// Read currently funded feed details.
 		/// # Returns
 		/// Details for funded feeds.
-		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData<Amount, Timestamp>>;
+		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData<Amount>>;
 
 		/// Read currently funded feeds.
 		/// # Returns
@@ -69,7 +69,7 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Identifier of reported data.
 		/// # Returns
 		/// All past tips.
-		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Amount, Timestamp>>;
+		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Amount>>;
 
 		/// Read a past tip for a query identifier and index.
 		/// # Arguments
@@ -77,7 +77,7 @@ sp_api::decl_runtime_apis! {
 		/// * `index` - The index of the tip.
 		/// # Returns
 		/// The past tip, if found.
-		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Amount, Timestamp>>;
+		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Amount>>;
 
 		/// Look up a query identifier from a data feed identifier.
 		/// # Arguments
@@ -121,7 +121,7 @@ sp_api::decl_runtime_apis! {
 		fn get_tips_by_address(user: AccountId) -> Amount;
 	}
 
-	pub trait TellorOracle<AccountId: Codec, Amount: Codec, BlockNumber: Codec, QueryId: Codec, StakeInfo: Codec, Timestamp: Codec, Value: Codec> where
+	pub trait TellorOracle<AccountId: Codec, Amount: Codec, BlockNumber: Codec, StakeInfo: Codec, Value: Codec> where
 	{
 		/// Returns the block number at a given timestamp.
 		/// # Arguments
@@ -266,7 +266,7 @@ sp_api::decl_runtime_apis! {
 		fn retrieve_data(query_id: QueryId, timestamp: Timestamp) -> Option<Value>;
 	}
 
-	pub trait TellorGovernance<AccountId: Codec, Amount: Codec, BlockNumber: Codec, DisputeId: Codec, QueryId: Codec, Timestamp: Codec, Value: Codec> where
+	pub trait TellorGovernance<AccountId: Codec, Amount: Codec, BlockNumber: Codec, Value: Codec> where
 	{
 		/// Determines if an account voted for a specific dispute round.
 		/// # Arguments

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -266,15 +266,16 @@ sp_api::decl_runtime_apis! {
 		fn retrieve_data(query_id: QueryId, timestamp: Timestamp) -> Option<Value>;
 	}
 
-	pub trait TellorGovernance<AccountId: Codec, Amount: Codec, BlockNumber: Codec, DisputeId: Codec, QueryId: Codec, Timestamp: Codec, Value: Codec, VoteCount: Codec, VoteId: Codec> where
+	pub trait TellorGovernance<AccountId: Codec, Amount: Codec, BlockNumber: Codec, DisputeId: Codec, QueryId: Codec, Timestamp: Codec, Value: Codec> where
 	{
-		/// Determines if an account voted for a specific dispute.
+		/// Determines if an account voted for a specific dispute round.
 		/// # Arguments
 		/// * `dispute_id` - The identifier of the dispute.
+		/// * `vote_round` - The vote round.
 		/// * `voter` - The account of the voter to check.
 		/// # Returns
-		/// Whether or not the account voted for the specific dispute.
-		fn did_vote(dispute_id: DisputeId, voter: AccountId) -> bool;
+		/// Whether or not the account voted for the specific dispute round.
+		fn did_vote(dispute_id: DisputeId, vote_round: u32, voter: AccountId) -> bool;
 
 		/// Get the latest dispute fee.
 		/// # Returns
@@ -307,22 +308,23 @@ sp_api::decl_runtime_apis! {
 		/// Returns the total number of votes
 		/// # Returns
 		/// The total number of votes.
-		fn get_vote_count() -> VoteCount;
+		fn get_vote_count() -> u128;
 
 		/// Returns info on a vote for a given dispute identifier.
 		/// # Arguments
 		/// * `dispute_id` - Identifier of a specific dispute.
+		/// * `vote_round` - The vote round.
 		/// # Returns
 		/// Information on a vote for a given dispute identifier including: the vote identifier, the
 		/// vote information, whether it has been executed, the vote result and the dispute initiator.
-		fn get_vote_info(dispute_id: DisputeId) -> Option<(VoteId,VoteInfo<Amount,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)>;
+		fn get_vote_info(dispute_id: DisputeId, vote_round: u32) -> Option<(VoteInfo<Amount,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)>;
 
-		/// Returns the voting rounds for a given vote identifier.
+		/// Returns the voting rounds for a given dispute identifier.
 		/// # Arguments
-		/// * `vote_id` - Identifier for a vote.
+		/// * `dispute_id` - Identifier for a dispute.
 		/// # Returns
-		/// Dispute identifiers of the vote rounds.
-		fn get_vote_rounds(vote_id: VoteId) -> Vec<DisputeId>;
+		/// The number of vote rounds for the dispute identifier.
+		fn get_vote_rounds(dispute_id: DisputeId) -> u32;
 
 		/// Returns the total number of votes cast by a voter.
 		/// # Arguments

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -293,7 +293,7 @@ mock_impl_runtime_apis! {
 	}
 
 	impl crate::TellorGovernance<Block, AccountId, Amount, BlockNumber, DisputeId, QueryId, Moment, Value> for Test {
-		fn did_vote(dispute_id: DisputeId, vote_round: u32, voter: AccountId) -> bool {
+		fn did_vote(dispute_id: DisputeId, vote_round: u8, voter: AccountId) -> bool {
 			tellor::Pallet::<Test>::did_vote(dispute_id, vote_round, voter)
 		}
 
@@ -317,7 +317,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_vote_count()
 		}
 
-		fn get_vote_info(dispute_id: DisputeId, vote_round: u32) -> Option<(VoteInfo<Amount,BlockNumber, Moment>,bool,Option<VoteResult>,AccountId)> {
+		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<Amount,BlockNumber, Moment>,bool,Option<VoteResult>,AccountId)> {
 			tellor::Pallet::<Test>::get_vote_info(dispute_id, vote_round).map(|v| (
 			VoteInfo{
 					vote_round: v.vote_round,
@@ -337,7 +337,7 @@ mock_impl_runtime_apis! {
 			v.initiator))
 		}
 
-		fn get_vote_rounds(dispute_id: DisputeId) -> u32 {
+		fn get_vote_rounds(dispute_id: DisputeId) -> u8 {
 			tellor::Pallet::<Test>::get_vote_rounds(dispute_id)
 		}
 

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -17,7 +17,10 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 };
 use std::time::{SystemTime, UNIX_EPOCH};
-use tellor::{EnsureGovernance, EnsureStaking, FeedDetails, Tip, VoteResult};
+use tellor::{
+	DisputeId, EnsureGovernance, EnsureStaking, FeedDetails, FeedId, QueryId, Timestamp, Tip,
+	VoteResult,
+};
 use xcm::latest::prelude::*;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -26,13 +29,8 @@ type Block = frame_system::mocking::MockBlock<Test>;
 type AccountId = u64;
 type Amount = u64;
 type BlockNumber = u64;
-type DisputeId = H256;
-type QueryId = H256;
 type MaxValueLength = ConstU32<4>;
-type Moment = u64;
-type FeedId = H256;
-type StakeInfo =
-	tellor::StakeInfo<Amount, <Test as tellor::Config>::MaxQueriesPerReporter, QueryId, Moment>;
+type StakeInfo = tellor::StakeInfo<Amount, <Test as tellor::Config>::MaxQueriesPerReporter>;
 type Value = BoundedVec<u8, MaxValueLength>;
 
 // Configure a mock runtime to test implementation of the runtime-api
@@ -44,7 +42,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system,
 		Balances: pallet_balances,
-		Timestamp: pallet_timestamp,
+		Time: pallet_timestamp,
 		Tellor: tellor,
 	}
 );
@@ -86,7 +84,7 @@ impl pallet_balances::Config for Test {
 	type ReserveIdentifier = [u8; 8];
 }
 impl pallet_timestamp::Config for Test {
-	type Moment = Moment;
+	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = ConstU64<1>;
 	type WeightInfo = ();
@@ -118,7 +116,7 @@ impl tellor::Config for Test {
 	type Registry = ();
 	type Staking = ();
 	type StakingOrigin = EnsureStaking;
-	type Time = Timestamp;
+	type Time = Time;
 	type Token = Balances;
 	type ValueConverter = ();
 	type Xcm = TestSendXcm;
@@ -139,7 +137,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 }
 
 mock_impl_runtime_apis! {
-	impl crate::TellorAutoPay<Block, AccountId, Amount, FeedId, QueryId, Moment> for Test {
+	impl crate::TellorAutoPay<Block, AccountId, Amount> for Test {
 		fn get_current_feeds(query_id: QueryId) -> Vec<FeedId>{
 			tellor::Pallet::<Test>::get_current_feeds(query_id)
 		}
@@ -148,11 +146,11 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_current_tip(query_id)
 		}
 
-		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails<Amount, Moment>> {
+		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails<Amount>> {
 			tellor::Pallet::<Test>::get_data_feed(feed_id)
 		}
 
-		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData<Amount, Moment>> {
+		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData<Amount>> {
 			tellor::Pallet::<Test>::get_funded_feed_details().into_iter()
 			.map(|(details, query_data)| FeedDetailsWithQueryData {
 				details: details,
@@ -181,11 +179,11 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_past_tip_count(query_id)
 		}
 
-		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Amount, Moment>> {
+		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Amount>> {
 			tellor::Pallet::<Test>::get_past_tips(query_id)
 		}
 
-		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Amount, Moment>>{
+		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Amount>>{
 			tellor::Pallet::<Test>::get_past_tip_by_index(query_id, index)
 		}
 
@@ -193,15 +191,15 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_query_id_from_feed_id(feed_id)
 		}
 
-		fn get_reward_amount(feed_id: FeedId, query_id: QueryId, timestamps: Vec<Moment>) -> Amount{
+		fn get_reward_amount(feed_id: FeedId, query_id: QueryId, timestamps: Vec<Timestamp>) -> Amount{
 			tellor::Pallet::<Test>::get_reward_amount(feed_id, query_id, timestamps)
 		}
 
-		fn get_reward_claimed_status(feed_id: FeedId, query_id: QueryId, timestamp: Moment) -> Option<bool>{
+		fn get_reward_claimed_status(feed_id: FeedId, query_id: QueryId, timestamp: Timestamp) -> Option<bool>{
 			tellor::Pallet::<Test>::get_reward_claimed_status(feed_id, query_id, timestamp)
 		}
 
-		fn get_reward_claim_status_list(feed_id: FeedId, query_id: QueryId, timestamps: Vec<Moment>) -> Vec<bool>{
+		fn get_reward_claim_status_list(feed_id: FeedId, query_id: QueryId, timestamps: Vec<Timestamp>) -> Vec<bool>{
 			tellor::Pallet::<Test>::get_reward_claim_status_list(feed_id, query_id, timestamps)
 		}
 
@@ -210,8 +208,8 @@ mock_impl_runtime_apis! {
 		}
 	}
 
-	impl crate::TellorOracle<Block, AccountId, Amount, BlockNumber, QueryId, StakeInfo, Moment, Value> for Test {
-		fn get_block_number_by_timestamp(query_id: QueryId, timestamp: Moment) -> Option<BlockNumber> {
+	impl crate::TellorOracle<Block, AccountId, Amount, BlockNumber, StakeInfo, Value> for Test {
+		fn get_block_number_by_timestamp(query_id: QueryId, timestamp: Timestamp) -> Option<BlockNumber> {
 			tellor::Pallet::<Test>::get_block_number_by_timestamp(query_id, timestamp)
 		}
 
@@ -219,7 +217,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_current_value(query_id)
 		}
 
-		fn get_data_before(query_id: QueryId, timestamp: Moment) -> Option<(Value, Moment)>{
+		fn get_data_before(query_id: QueryId, timestamp: Timestamp) -> Option<(Value, Timestamp)>{
 			tellor::Pallet::<Test>::get_data_before(query_id, timestamp)
 		}
 
@@ -227,19 +225,19 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_new_value_count_by_query_id(query_id) as u32
 		}
 
-		fn get_report_details(query_id: QueryId, timestamp: Moment) -> Option<(AccountId, bool)>{
+		fn get_report_details(query_id: QueryId, timestamp: Timestamp) -> Option<(AccountId, bool)>{
 			tellor::Pallet::<Test>::get_report_details(query_id, timestamp)
 		}
 
-		fn get_reporter_by_timestamp(query_id: QueryId, timestamp: Moment) -> Option<AccountId>{
+		fn get_reporter_by_timestamp(query_id: QueryId, timestamp: Timestamp) -> Option<AccountId>{
 			tellor::Pallet::<Test>::get_reporter_by_timestamp(query_id, timestamp)
 		}
 
-		fn get_reporter_last_timestamp(reporter: AccountId) -> Option<Moment>{
+		fn get_reporter_last_timestamp(reporter: AccountId) -> Option<Timestamp>{
 			tellor::Pallet::<Test>::get_reporter_last_timestamp(reporter)
 		}
 
-		fn get_reporting_lock() -> Moment {
+		fn get_reporting_lock() -> Timestamp {
 			tellor::Pallet::<Test>::get_reporting_lock()
 		}
 
@@ -259,19 +257,19 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_staker_info(staker)
 		}
 
-		fn get_time_of_last_new_value() -> Option<Moment> {
+		fn get_time_of_last_new_value() -> Option<Timestamp> {
 			tellor::Pallet::<Test>::get_time_of_last_new_value()
 		}
 
-		fn get_timestamp_by_query_id_and_index(query_id: QueryId, index: u32) -> Option<Moment>{
+		fn get_timestamp_by_query_id_and_index(query_id: QueryId, index: u32) -> Option<Timestamp>{
 			tellor::Pallet::<Test>::get_timestamp_by_query_id_and_index(query_id, index as usize)
 		}
 
-		fn get_index_for_data_before(query_id: QueryId, timestamp: Moment) -> Option<u32> {
+		fn get_index_for_data_before(query_id: QueryId, timestamp: Timestamp) -> Option<u32> {
 			tellor::Pallet::<Test>::get_index_for_data_before(query_id, timestamp).map(|index| index as u32)
 		}
 
-		fn get_timestamp_index_by_timestamp(query_id: QueryId, timestamp: Moment) -> Option<u32> {
+		fn get_timestamp_index_by_timestamp(query_id: QueryId, timestamp: Timestamp) -> Option<u32> {
 			tellor::Pallet::<Test>::get_timestamp_index_by_timestamp(query_id, timestamp)
 		}
 
@@ -283,16 +281,16 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_total_stakers()
 		}
 
-		fn is_in_dispute(query_id: QueryId, timestamp: Moment) -> bool{
+		fn is_in_dispute(query_id: QueryId, timestamp: Timestamp) -> bool{
 			tellor::Pallet::<Test>::is_in_dispute(query_id, timestamp)
 		}
 
-		fn retrieve_data(query_id: QueryId, timestamp: Moment) -> Option<Value>{
+		fn retrieve_data(query_id: QueryId, timestamp: Timestamp) -> Option<Value>{
 			tellor::Pallet::<Test>::retrieve_data(query_id, timestamp)
 		}
 	}
 
-	impl crate::TellorGovernance<Block, AccountId, Amount, BlockNumber, DisputeId, QueryId, Moment, Value> for Test {
+	impl crate::TellorGovernance<Block, AccountId, Amount, BlockNumber, Value> for Test {
 		fn did_vote(dispute_id: DisputeId, vote_round: u8, voter: AccountId) -> bool {
 			tellor::Pallet::<Test>::did_vote(dispute_id, vote_round, voter)
 		}
@@ -305,7 +303,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_disputes_by_reporter(reporter)
 		}
 
-		fn get_dispute_info(dispute_id: DisputeId) -> Option<(QueryId, Moment, Value, AccountId)> {
+		fn get_dispute_info(dispute_id: DisputeId) -> Option<(QueryId, Timestamp, Value, AccountId)> {
 			tellor::Pallet::<Test>::get_dispute_info(dispute_id)
 		}
 
@@ -317,7 +315,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_vote_count()
 		}
 
-		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<Amount,BlockNumber, Moment>,bool,Option<VoteResult>,AccountId)> {
+		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<Amount,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)> {
 			tellor::Pallet::<Test>::get_vote_info(dispute_id, vote_round).map(|v| (
 			VoteInfo{
 					vote_round: v.vote_round,
@@ -453,7 +451,7 @@ mod autopay {
 					&BLOCKID,
 					FeedId::random(),
 					QueryId::random(),
-					Timestamp::get()
+					Time::get()
 				)
 				.unwrap(),
 				None
@@ -495,8 +493,7 @@ mod oracle {
 	fn get_block_number_by_timestamp() {
 		new_test_ext().execute_with(|| {
 			assert_eq!(
-				Test.get_block_number_by_timestamp(&BLOCKID, QueryId::random(), Moment::default())
-					.unwrap(),
+				Test.get_block_number_by_timestamp(&BLOCKID, QueryId::random(), 0).unwrap(),
 				None
 			);
 		});
@@ -512,10 +509,7 @@ mod oracle {
 	#[test]
 	fn get_data_before() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(
-				Test.get_data_before(&BLOCKID, QueryId::random(), Moment::default()).unwrap(),
-				None
-			);
+			assert_eq!(Test.get_data_before(&BLOCKID, QueryId::random(), 0).unwrap(), None);
 		});
 	}
 
@@ -532,10 +526,7 @@ mod oracle {
 	#[test]
 	fn get_report_details() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(
-				Test.get_report_details(&BLOCKID, QueryId::random(), Moment::default()).unwrap(),
-				None
-			);
+			assert_eq!(Test.get_report_details(&BLOCKID, QueryId::random(), 0).unwrap(), None);
 		});
 	}
 
@@ -543,8 +534,7 @@ mod oracle {
 	fn get_reporter_by_timestamp() {
 		new_test_ext().execute_with(|| {
 			assert_eq!(
-				Test.get_reporter_by_timestamp(&BLOCKID, QueryId::random(), Moment::default())
-					.unwrap(),
+				Test.get_reporter_by_timestamp(&BLOCKID, QueryId::random(), 0).unwrap(),
 				None
 			);
 		});
@@ -661,20 +651,14 @@ mod oracle {
 	#[test]
 	fn is_in_dispute() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(
-				Test.is_in_dispute(&BLOCKID, QueryId::random(), Moment::default()).unwrap(),
-				false
-			);
+			assert_eq!(Test.is_in_dispute(&BLOCKID, QueryId::random(), 0).unwrap(), false);
 		});
 	}
 
 	#[test]
 	fn retrieve_data() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(
-				Test.retrieve_data(&BLOCKID, QueryId::random(), Moment::default()).unwrap(),
-				None
-			);
+			assert_eq!(Test.retrieve_data(&BLOCKID, QueryId::random(), 0).unwrap(), None);
 		});
 	}
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -101,7 +101,7 @@ pub(crate) mod tests {
 	use super::Call;
 	use crate::types::Address;
 	use ethabi::{encode, Param, ParamType, Token};
-	use sp_core::U256;
+	use sp_core::{keccak_256, U256};
 
 	// Helper for creating a parameter
 	pub(crate) fn param(name: &str, kind: ParamType) -> Param {
@@ -123,6 +123,15 @@ pub(crate) mod tests {
 		assert_eq!(
 			encode(&[Token::Uint(U256::from(value))])[..],
 			Call::new(&[0; 4]).uint(value).encode()[4..]
+		);
+	}
+
+	#[test]
+	fn encodes_fixed_bytes() {
+		let value = keccak_256(b"hello");
+		assert_eq!(
+			encode(&[Token::FixedBytes(value.to_vec())])[..],
+			Call::new(&[0; 4]).fixed_bytes(&value).encode()[4..]
 		);
 	}
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -522,7 +522,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of reported data.
 	/// # Returns
 	/// All past tips.
-	pub fn get_past_tips(query_id: QueryId) -> Vec<Tip<AmountOf<T>, Timestamp>> {
+	pub fn get_past_tips(query_id: QueryId) -> Vec<Tip<AmountOf<T>>> {
 		<Tips<T>>::get(query_id).map_or_else(Vec::default, |t| t.to_vec())
 	}
 
@@ -532,10 +532,7 @@ impl<T: Config> Pallet<T> {
 	/// * `index` - The index of the tip.
 	/// # Returns
 	/// The past tip, if found.
-	pub fn get_past_tip_by_index(
-		query_id: QueryId,
-		index: u32,
-	) -> Option<Tip<AmountOf<T>, Timestamp>> {
+	pub fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<AmountOf<T>>> {
 		<Tips<T>>::get(query_id).and_then(|t| t.get(index as usize).cloned())
 	}
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -24,7 +24,7 @@ impl<T: Config> Pallet<T> {
 	/// * `voter` - The account of the voter to check.
 	/// # Returns
 	/// Whether or not the account voted for the specific dispute round.
-	pub fn did_vote(dispute_id: DisputeIdOf<T>, vote_round: u32, voter: AccountIdOf<T>) -> bool {
+	pub fn did_vote(dispute_id: DisputeIdOf<T>, vote_round: u8, voter: AccountIdOf<T>) -> bool {
 		<VoteInfo<T>>::get(dispute_id, vote_round)
 			.and_then(|v| v.voted.get(&voter).copied())
 			.unwrap_or_default()
@@ -37,7 +37,7 @@ impl<T: Config> Pallet<T> {
 	/// * `result` - The result of the dispute, as determined by governance.
 	pub(super) fn execute_vote(
 		dispute_id: DisputeIdOf<T>,
-		vote_round: u32,
+		vote_round: u8,
 		result: VoteResult,
 	) -> DispatchResult {
 		// Ensure validity of id
@@ -843,7 +843,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// Information on a vote for a given dispute identifier including: the vote identifier, the
 	/// vote information, whether it has been executed, the vote result and the dispute initiator.
-	pub fn get_vote_info(dispute_id: DisputeIdOf<T>, vote_round: u32) -> Option<VoteOf<T>> {
+	pub fn get_vote_info(dispute_id: DisputeIdOf<T>, vote_round: u8) -> Option<VoteOf<T>> {
 		<VoteInfo<T>>::get(dispute_id, vote_round)
 	}
 
@@ -852,7 +852,7 @@ impl<T: Config> Pallet<T> {
 	/// * `dispute_id` - Identifier for a dispute.
 	/// # Returns
 	/// The number of vote rounds for the dispute identifier.
-	pub fn get_vote_rounds(dispute_id: DisputeIdOf<T>) -> u32 {
+	pub fn get_vote_rounds(dispute_id: DisputeIdOf<T>) -> u8 {
 		<VoteRounds<T>>::get(dispute_id)
 	}
 
@@ -933,7 +933,7 @@ impl<T: Config> Pallet<T> {
 	/// # Arguments
 	/// * `dispute_id` - The dispute identifier.
 	/// * `vote_round` - The vote round.
-	pub(crate) fn tally_votes(dispute_id: DisputeIdOf<T>, vote_round: u32) -> DispatchResult {
+	pub(crate) fn tally_votes(dispute_id: DisputeIdOf<T>, vote_round: u8) -> DispatchResult {
 		// Ensure vote has not been executed and that vote has not been tallied
 		let initiator = <VoteInfo<T>>::try_mutate(dispute_id, vote_round, |maybe| match maybe {
 			None => Err(Error::<T>::InvalidDispute),

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,4 +1,5 @@
 use super::*;
+use sp_runtime::traits::Hash;
 
 impl<T: Config> Pallet<T> {
 	pub(super) fn add_staking_rewards(amount: AmountOf<T>) -> DispatchResult {
@@ -16,14 +17,15 @@ impl<T: Config> Pallet<T> {
 		T::ValueConverter::convert(value.into_inner()).ok_or(Error::<T>::ValueConversionError)
 	}
 
-	/// Determines if an account voted for a specific dispute.
+	/// Determines if an account voted for a specific dispute round.
 	/// # Arguments
 	/// * `dispute_id` - The identifier of the dispute.
+	/// * `vote_round` - The vote round.
 	/// * `voter` - The account of the voter to check.
 	/// # Returns
-	/// Whether or not the account voted for the specific dispute.
-	pub fn did_vote(dispute_id: DisputeIdOf<T>, voter: AccountIdOf<T>) -> bool {
-		<VoteInfo<T>>::get(dispute_id)
+	/// Whether or not the account voted for the specific dispute round.
+	pub fn did_vote(dispute_id: DisputeIdOf<T>, vote_round: u32, voter: AccountIdOf<T>) -> bool {
+		<VoteInfo<T>>::get(dispute_id, vote_round)
 			.and_then(|v| v.voted.get(&voter).copied())
 			.unwrap_or_default()
 	}
@@ -31,14 +33,21 @@ impl<T: Config> Pallet<T> {
 	/// Executes the vote.
 	/// # Arguments
 	/// * `dispute_id` - The identifier of the dispute.
+	/// * `vote_round` - The vote round.
 	/// * `result` - The result of the dispute, as determined by governance.
-	pub(super) fn execute_vote(dispute_id: DisputeIdOf<T>, result: VoteResult) -> DispatchResult {
+	pub(super) fn execute_vote(
+		dispute_id: DisputeIdOf<T>,
+		vote_round: u32,
+		result: VoteResult,
+	) -> DispatchResult {
 		// Ensure validity of id
 		ensure!(
-			dispute_id <= <VoteCount<T>>::get() && dispute_id > <DisputeIdOf<T>>::default(),
+			dispute_id != <DisputeIdOf<T>>::default() &&
+				dispute_id != Keccak256::hash(&[]) &&
+				<DisputeInfo<T>>::contains_key(dispute_id),
 			Error::<T>::InvalidDispute
 		);
-		<VoteInfo<T>>::try_mutate(dispute_id, |maybe| match maybe {
+		<VoteInfo<T>>::try_mutate(dispute_id, vote_round, |maybe| match maybe {
 			None => Err(Error::<T>::InvalidVote),
 			Some(vote) => {
 				// Ensure vote has not already been executed, and vote must be tallied
@@ -46,7 +55,7 @@ impl<T: Config> Pallet<T> {
 				ensure!(vote.tally_date > 0, Error::<T>::VoteNotTallied);
 				// Ensure vote must be final vote and that time has to be pass after the vote is tallied
 				ensure!(
-					<VoteRounds<T>>::get(vote.identifier).len() == vote.vote_round as usize,
+					<VoteRounds<T>>::get(vote.identifier) == vote.vote_round,
 					Error::VoteNotFinal
 				);
 				ensure!(
@@ -246,7 +255,7 @@ impl<T: Config> Pallet<T> {
 	/// # Arguments
 	/// * `reporter` - The account of the reporter to check for.
 	/// # Returns
-	/// Dispute identifiers for a reporter.
+	/// Dispute identifiers for a reporter, in no particular order.
 	pub fn get_disputes_by_reporter(reporter: AccountIdOf<T>) -> Vec<DisputeIdOf<T>> {
 		<DisputeIdsByReporter<T>>::iter_key_prefix(reporter).collect()
 	}
@@ -823,27 +832,28 @@ impl<T: Config> Pallet<T> {
 	/// Returns the total number of votes
 	/// # Returns
 	/// The total number of votes.
-	pub fn get_vote_count() -> VoteCountOf<T> {
+	pub fn get_vote_count() -> u128 {
 		<VoteCount<T>>::get()
 	}
 
 	/// Returns info on a vote for a given dispute identifier.
 	/// # Arguments
 	/// * `dispute_id` - Identifier of a specific dispute.
+	/// * `vote_round` - The vote round.
 	/// # Returns
 	/// Information on a vote for a given dispute identifier including: the vote identifier, the
 	/// vote information, whether it has been executed, the vote result and the dispute initiator.
-	pub fn get_vote_info(dispute_id: DisputeIdOf<T>) -> Option<VoteOf<T>> {
-		<VoteInfo<T>>::get(dispute_id)
+	pub fn get_vote_info(dispute_id: DisputeIdOf<T>, vote_round: u32) -> Option<VoteOf<T>> {
+		<VoteInfo<T>>::get(dispute_id, vote_round)
 	}
 
-	/// Returns the voting rounds for a given vote identifier.
+	/// Returns the voting rounds for a given dispute identifier.
 	/// # Arguments
-	/// * `vote_id` - Identifier for a vote.
+	/// * `dispute_id` - Identifier for a dispute.
 	/// # Returns
-	/// Dispute identifiers of the vote rounds.
-	pub fn get_vote_rounds(vote_id: VoteId) -> Vec<DisputeIdOf<T>> {
-		<VoteRounds<T>>::get(vote_id).into_inner()
+	/// The number of vote rounds for the dispute identifier.
+	pub fn get_vote_rounds(dispute_id: DisputeIdOf<T>) -> u32 {
+		<VoteRounds<T>>::get(dispute_id)
 	}
 
 	/// Returns the total number of votes cast by a voter.
@@ -922,14 +932,17 @@ impl<T: Config> Pallet<T> {
 	/// Tallies the votes and begins the challenge period.
 	/// # Arguments
 	/// * `dispute_id` - The dispute identifier.
-	pub(crate) fn tally_votes(dispute_id: DisputeIdOf<T>) -> DispatchResult {
+	/// * `vote_round` - The vote round.
+	pub(crate) fn tally_votes(dispute_id: DisputeIdOf<T>, vote_round: u32) -> DispatchResult {
 		// Ensure vote has not been executed and that vote has not been tallied
-		let initiator = <VoteInfo<T>>::try_mutate(dispute_id, |maybe| match maybe {
+		let initiator = <VoteInfo<T>>::try_mutate(dispute_id, vote_round, |maybe| match maybe {
 			None => Err(Error::<T>::InvalidDispute),
 			Some(vote) => {
 				ensure!(vote.tally_date == 0, Error::VoteAlreadyTallied);
 				ensure!(
-					dispute_id <= <VoteCount<T>>::get() && dispute_id > <DisputeIdOf<T>>::default(),
+					dispute_id != <DisputeIdOf<T>>::default() &&
+						dispute_id != Keccak256::hash(&[]) &&
+						<DisputeInfo<T>>::contains_key(dispute_id),
 					Error::InvalidDispute
 				);
 				// Determine appropriate vote duration dispute round

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,13 @@ use sp_runtime::{
 };
 use sp_std::vec::Vec;
 pub use traits::{SendXcm, UsingTellor};
+use types::*;
 pub use types::{
 	autopay::{FeedDetails, Tip},
 	governance::VoteResult,
 	oracle::StakeInfo,
-	Address,
+	Address, DisputeId, FeedId, QueryId, Timestamp,
 };
-use types::{QueryId, *};
 
 #[cfg(test)]
 mod mock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,9 +238,9 @@ pub mod pallet {
 	pub type VoteCount<T> = StorageValue<_, u128, ValueQuery>;
 	#[pallet::storage]
 	pub type VoteInfo<T> =
-		StorageDoubleMap<_, Blake2_128Concat, DisputeIdOf<T>, Blake2_128Concat, u32, VoteOf<T>>;
+		StorageDoubleMap<_, Blake2_128Concat, DisputeIdOf<T>, Blake2_128Concat, u8, VoteOf<T>>;
 	#[pallet::storage]
-	pub type VoteRounds<T> = StorageMap<_, Blake2_128Concat, DisputeIdOf<T>, u32, ValueQuery>;
+	pub type VoteRounds<T> = StorageMap<_, Blake2_128Concat, DisputeIdOf<T>, u8, ValueQuery>;
 	#[pallet::storage]
 	pub type VoteTallyByAddress<T> =
 		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, u128, ValueQuery>;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -24,8 +24,9 @@ type Balance = u64;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
+pub(crate) const EVM_PARA_ID: u32 = 2000;
 pub(crate) const PALLET_INDEX: u8 = 3;
-pub(crate) const PARA_ID: u32 = 2000;
+pub(crate) const PARA_ID: u32 = 3000;
 pub(crate) const UNIT: u64 = 1_000_000_000_000;
 
 // Configure a mock runtime to test the pallet.
@@ -96,16 +97,15 @@ static STAKING: Lazy<[u8; 20]> = Lazy::new(|| Address::random().into());
 parameter_types! {
 	pub const TellorPalletId: PalletId = PalletId(*b"py/tellr");
 	pub const ParachainId: u32 = PARA_ID;
-	pub TellorRegistry: ContractLocation = (PARA_ID, *REGISTRY).into();
-	pub TellorGovernance: ContractLocation = (PARA_ID, *GOVERNANCE).into();
-	pub TellorStaking: ContractLocation = (PARA_ID, *STAKING).into();
+	pub TellorRegistry: ContractLocation = (EVM_PARA_ID, *REGISTRY).into();
+	pub TellorGovernance: ContractLocation = (EVM_PARA_ID, *GOVERNANCE).into();
+	pub TellorStaking: ContractLocation = (EVM_PARA_ID, *STAKING).into();
 }
 
 impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type Amount = u64;
-	type DisputeId = u32;
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;
@@ -119,7 +119,6 @@ impl tellor::Config for Test {
 	type MaxTipsPerQuery = ConstU32<10>;
 	type MaxValueLength = ConstU32<128>; // Chain may want to store any raw bytes, so ValueConverter needs to handle conversion to price for threshold checks
 	type MaxVotes = ConstU32<10>;
-	type MaxVoteRounds = ConstU32<10>;
 	type PalletId = TellorPalletId;
 	type ParachainId = ParachainId;
 	type Price = u128;

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -539,7 +539,8 @@ fn get_dispute_info() {
 				query_data.clone(),
 			));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
-			let dispute_info = Tellor::get_dispute_info(dispute_id(PARA_ID, query_id, now())).unwrap();
+			let dispute_info =
+				Tellor::get_dispute_info(dispute_id(PARA_ID, query_id, now())).unwrap();
 			assert_eq!(dispute_info.0, query_id, "disputed query id should be correct");
 			assert_eq!(dispute_info.1, now(), "disputed timestamp should be correct");
 			assert_eq!(dispute_info.2, uint_value(100), "disputed value should be correct");
@@ -579,7 +580,7 @@ fn get_disputes_by_reporter() {
 				0,
 				query_data.clone(),
 			));
-			assert_eq!(Tellor::get_disputes_by_reporter(reporter), Vec::<DisputeIdOf<Test>>::new());
+			assert_eq!(Tellor::get_disputes_by_reporter(reporter), Vec::<DisputeId>::new());
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_initiator),
 				query_id,
@@ -993,7 +994,7 @@ fn get_tips_by_address() {
 	});
 }
 
-fn sort(mut disputes: Vec<DisputeIdOf<Test>>) -> Vec<DisputeIdOf<Test>> {
+fn sort(mut disputes: Vec<DisputeId>) -> Vec<DisputeId> {
 	disputes.sort();
 	disputes
 }

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -60,9 +60,9 @@ fn begin_dispute() {
 				query_id,
 				timestamp
 			));
-			let dispute_id = 1;
+			let dispute_id = dispute_id(PARA_ID, query_id, timestamp);
 			let dispute_info = Tellor::get_dispute_info(dispute_id).unwrap();
-			let vote_info = Tellor::get_vote_info(dispute_id).unwrap();
+			let vote_info = Tellor::get_vote_info(dispute_id, 1).unwrap();
 			assert_eq!(Tellor::get_vote_count(), 1, "vote count should be correct");
 			assert_eq!(
 				dispute_info,
@@ -77,7 +77,7 @@ fn begin_dispute() {
 			);
 			assert_eq!(
 				Tellor::get_vote_rounds(vote_info.identifier),
-				vec![1],
+				1,
 				"number of vote rounds should be correct"
 			);
 			// todo
@@ -87,7 +87,7 @@ fn begin_dispute() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::tally_votes(dispute_id));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 		});
 
 		// Report slash after tally dispute period
@@ -162,7 +162,13 @@ fn begins_dispute_xcm() {
 			// todo: check remaining instructions
 
 			System::assert_last_event(
-				Event::NewDispute { dispute_id: 1, query_id, timestamp, reporter }.into(),
+				Event::NewDispute {
+					dispute_id: dispute_id(PARA_ID, query_id, timestamp),
+					query_id,
+					timestamp,
+					reporter,
+				}
+				.into(),
 			);
 		});
 	});
@@ -188,7 +194,7 @@ fn execute_vote() {
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L85
 	ext.execute_with(|| {
-		let (timestamp, identifier) = with_block(|| {
+		let (timestamp_1, dispute_1) = with_block(|| {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter_1,
@@ -196,7 +202,7 @@ fn execute_vote() {
 				Address::random()
 			));
 			//let balance_1 = Balances::balance(&dispute_reporter);
-			assert_noop!(Tellor::execute_vote(1, result), Error::InvalidDispute); // vote id must be valid
+			assert_noop!(Tellor::execute_vote(H256::random(), 1, result), Error::InvalidDispute); // dispute id must be valid
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter_1),
 				query_id,
@@ -204,6 +210,7 @@ fn execute_vote() {
 				0,
 				query_data.clone(),
 			));
+			let timestamp_1 = now();
 			// todo
 			// assert_noop!(
 			// 	Tellor::begin_dispute(RuntimeOrigin::signed(4), query_id, now()),
@@ -212,54 +219,56 @@ fn execute_vote() {
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_reporter),
 				query_id,
-				now()
+				timestamp_1
 			));
 			//let balance_2 = Balances::balance(&dispute_reporter);
+			let dispute_1 = dispute_id(PARA_ID, query_id, timestamp_1);
 			assert_eq!(
-				Tellor::get_dispute_info(1).unwrap(),
-				(query_id, now(), uint_value(100), reporter_1)
+				Tellor::get_dispute_info(dispute_1).unwrap(),
+				(query_id, timestamp_1, uint_value(100), reporter_1)
 			);
 			assert_eq!(
 				Tellor::get_open_disputes_on_id(query_id),
 				1,
 				"open disputes on id should be correct"
 			);
-			let parachain_id: u32 = ParachainId::get();
-			let identifier = keccak_256(&ethabi::encode(&vec![
-				Token::Uint(parachain_id.into()),
-				Token::FixedBytes(query_id.0.to_vec()),
-				Token::Uint(now().into()),
-			]))
-			.into();
 			assert_eq!(
-				Tellor::get_vote_rounds(identifier),
-				vec![1],
+				Tellor::get_vote_rounds(dispute_1),
+				1,
 				"number of vote rounds should be correct"
 			);
 			// todo: assert_eq!(balance_1 - balance_2, token(10), "dispute fee paid should be correct");
 
-			assert_noop!(Tellor::execute_vote(10, result), Error::InvalidDispute); // dispute id must exist
-			assert_noop!(Tellor::execute_vote(1, result), Error::VoteNotTallied); // vote must be tallied
-			(now(), identifier)
+			assert_noop!(Tellor::execute_vote(H256::random(), 1, result), Error::InvalidDispute); // dispute id must exist
+			assert_noop!(Tellor::execute_vote(dispute_1, 10, result), Error::InvalidVote); // vote round must exist
+			assert_noop!(Tellor::execute_vote(dispute_1, 1, result), Error::VoteNotTallied); // vote must be tallied
+			(timestamp_1, dispute_1)
 		});
 
 		// Tally votes after vote duration
 		with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::tally_votes(1));
-			assert_noop!(Tellor::execute_vote(1, result), Error::TallyDisputePeriodActive); // a day must pass before execution
+			assert_ok!(Tellor::tally_votes(dispute_1, 1));
+			assert_noop!(
+				Tellor::execute_vote(dispute_1, 1, result),
+				Error::TallyDisputePeriodActive
+			); // a day must pass before execution
 		});
 
 		// Execute after tally dispute period
-		let timestamp = with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::execute_vote(1, result));
-			assert_noop!(Tellor::execute_vote(1, result), Error::VoteAlreadyExecuted); // vote already executed
+		let (timestamp_2, dispute_2) = with_block_after(86_400 * 2, || {
+			assert_ok!(Tellor::execute_vote(dispute_1, 1, result));
+			assert_noop!(Tellor::execute_vote(dispute_1, 1, result), Error::VoteAlreadyExecuted); // vote already executed
 			assert_noop!(
-				Tellor::begin_dispute(RuntimeOrigin::signed(dispute_reporter), query_id, timestamp),
+				Tellor::begin_dispute(
+					RuntimeOrigin::signed(dispute_reporter),
+					query_id,
+					timestamp_1
+				),
 				Error::DisputeRoundReportingPeriodExpired
 			); // assert second dispute started within a day
 
-			let vote = Tellor::get_vote_info(1).unwrap();
-			assert_eq!(vote.identifier, identifier, "identifier should be correct");
+			let vote = Tellor::get_vote_info(dispute_1, 1).unwrap();
+			assert_eq!(vote.identifier, dispute_1, "identifier should be correct");
 			assert_eq!(vote.vote_round, 1, "vote round should be correct");
 			assert_eq!(vote.executed, true, "vote should be executed");
 			assert_eq!(vote.result, Some(result), "vote should pass");
@@ -277,35 +286,40 @@ fn execute_vote() {
 				0,
 				query_data.clone(),
 			));
+			let timestamp_2 = now();
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_reporter),
 				query_id,
-				now()
+				timestamp_2
 			));
-			now()
+			(timestamp_2, dispute_id(PARA_ID, query_id, timestamp_2))
 		});
 
-		with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::tally_votes(2));
-			// start new round
+		let dispute_3 = with_block_after(86_400 * 2, || {
+			assert_ok!(Tellor::tally_votes(dispute_2, 1));
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_reporter),
 				query_id,
-				timestamp
+				timestamp_2
 			));
+			dispute_id(PARA_ID, query_id, timestamp_2)
 		});
 
 		with_block_after(86_400 * 2, || {
-			assert_noop!(Tellor::execute_vote(2, result), Error::VoteNotFinal); // vote must be the final vote
+			assert_noop!(Tellor::execute_vote(dispute_2, 1, result), Error::VoteNotFinal);
+			// vote must be the final vote
 		});
 
 		with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::tally_votes(3));
-			assert_noop!(Tellor::execute_vote(3, result), Error::TallyDisputePeriodActive); // must wait longer
+			assert_ok!(Tellor::tally_votes(dispute_3, 2));
+			assert_noop!(
+				Tellor::execute_vote(dispute_3, 2, result),
+				Error::TallyDisputePeriodActive
+			); // must wait longer
 		});
 
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(3, result));
+			assert_ok!(Tellor::execute_vote(dispute_3, 2, result));
 		});
 	});
 }
@@ -322,7 +336,7 @@ fn tally_votes() {
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L143
 	ext.execute_with(|| {
-		with_block(|| {
+		let dispute_id = with_block(|| {
 			// 1) dispute could not have been tallied,
 			// 2) dispute does not exist,
 			// 3) cannot tally before the voting time has ended
@@ -339,18 +353,20 @@ fn tally_votes() {
 				0,
 				query_data.clone(),
 			));
-			assert_noop!(Tellor::tally_votes(1), Error::InvalidDispute); // Cannot tally a dispute that does not exist
+			assert_noop!(Tellor::tally_votes(H256::random(), 1), Error::InvalidDispute); // Cannot tally a dispute that does not exist
 
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
-			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), 1, Some(false)));
-			assert_noop!(Tellor::tally_votes(1), Error::VotingPeriodActive); // Time for voting has not elapsed
+			let dispute_id = super::dispute_id(PARA_ID, query_id, now());
+			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), dispute_id, Some(false)));
+			assert_noop!(Tellor::tally_votes(dispute_id, 1), Error::VotingPeriodActive); // Time for voting has not elapsed
+			dispute_id
 		});
 
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(1));
-			assert_noop!(Tellor::tally_votes(1), Error::VoteAlreadyTallied); // cannot re-tally a dispute
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
+			assert_noop!(Tellor::tally_votes(dispute_id, 1), Error::VoteAlreadyTallied); // cannot re-tally a dispute
 
-			let vote_info = Tellor::get_vote_info(1).unwrap();
+			let vote_info = Tellor::get_vote_info(dispute_id, 1).unwrap();
 			assert_eq!(vote_info.tally_date, now(), "Tally date should be correct");
 		});
 	});
@@ -369,7 +385,7 @@ fn vote() {
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L170
 	ext.execute_with(|| {
-		with_block(|| {
+		let dispute_id = with_block(|| {
 			// 1 dispute must exist
 			// 2) cannot have been tallied
 			// 3) sender has already voted
@@ -388,26 +404,28 @@ fn vote() {
 			));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter_2), query_id, now()));
 			assert_noop!(
-				Tellor::vote(RuntimeOrigin::signed(reporter_2), 2, Some(false)),
+				Tellor::vote(RuntimeOrigin::signed(reporter_2), H256::random(), Some(false)),
 				Error::InvalidVote
 			); // Can't vote on dispute does not exist
 
-			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter_1), 1, Some(true)));
-			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter_2), 1, Some(false)));
+			let dispute_id = super::dispute_id(PARA_ID, query_id, now());
+			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter_1), dispute_id, Some(true)));
+			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter_2), dispute_id, Some(false)));
 			assert_noop!(
-				Tellor::vote(RuntimeOrigin::signed(reporter_2), 1, Some(true)),
+				Tellor::vote(RuntimeOrigin::signed(reporter_2), dispute_id, Some(true)),
 				Error::AlreadyVoted
 			); // Sender has already voted
+			dispute_id
 		});
 
 		with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::tally_votes(1));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 			assert_noop!(
-				Tellor::vote(RuntimeOrigin::signed(reporter_2), 1, Some(true)),
+				Tellor::vote(RuntimeOrigin::signed(reporter_2), dispute_id, Some(true)),
 				Error::VoteAlreadyTallied
 			); // Vote has already been tallied
 
-			let vote_info = Tellor::get_vote_info(1).unwrap();
+			let vote_info = Tellor::get_vote_info(dispute_id, 1).unwrap();
 			assert_eq!(
 				vote_info.users,
 				Tally::<AmountOf<Test>>::default(),
@@ -423,9 +441,15 @@ fn vote() {
 				"reporters invalid tally should be correct"
 			);
 
-			assert!(Tellor::did_vote(1, reporter_2), "voter's voted status should be correct");
-			assert!(Tellor::did_vote(1, reporter_1), "voter's voted status should be correct");
-			assert!(!Tellor::did_vote(1, 3), "voter's voted status should be correct");
+			assert!(
+				Tellor::did_vote(dispute_id, 1, reporter_2),
+				"voter's voted status should be correct"
+			);
+			assert!(
+				Tellor::did_vote(dispute_id, 1, reporter_1),
+				"voter's voted status should be correct"
+			);
+			assert!(!Tellor::did_vote(dispute_id, 1, 3), "voter's voted status should be correct");
 
 			assert_eq!(
 				Tellor::get_vote_tally_by_address(reporter_2),
@@ -474,9 +498,16 @@ fn did_vote() {
 				query_data.clone(),
 			));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
-			assert!(!Tellor::did_vote(1, reporter), "voter's voted status should be correct");
-			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), 1, Some(true)));
-			assert!(Tellor::did_vote(1, reporter), "voter's voted status should be correct");
+			let dispute_id = super::dispute_id(PARA_ID, query_id, now());
+			assert!(
+				!Tellor::did_vote(dispute_id, 1, reporter),
+				"voter's voted status should be correct"
+			);
+			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), dispute_id, Some(true)));
+			assert!(
+				Tellor::did_vote(dispute_id, 1, reporter),
+				"voter's voted status should be correct"
+			);
 		});
 	});
 }
@@ -508,7 +539,7 @@ fn get_dispute_info() {
 				query_data.clone(),
 			));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
-			let dispute_info = Tellor::get_dispute_info(1).unwrap();
+			let dispute_info = Tellor::get_dispute_info(dispute_id(PARA_ID, query_id, now())).unwrap();
 			assert_eq!(dispute_info.0, query_id, "disputed query id should be correct");
 			assert_eq!(dispute_info.1, now(), "disputed timestamp should be correct");
 			assert_eq!(dispute_info.2, uint_value(100), "disputed value should be correct");
@@ -534,7 +565,7 @@ fn get_disputes_by_reporter() {
 	});
 
 	ext.execute_with(|| {
-		with_block(|| {
+		let dispute_id = with_block(|| {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
@@ -548,16 +579,16 @@ fn get_disputes_by_reporter() {
 				0,
 				query_data.clone(),
 			));
-			assert_eq!(Tellor::get_disputes_by_reporter(reporter), Vec::<u32>::new());
+			assert_eq!(Tellor::get_disputes_by_reporter(reporter), Vec::<DisputeIdOf<Test>>::new());
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_initiator),
 				query_id,
 				now()
 			));
-			now()
+			dispute_id(PARA_ID, query_id, now())
 		});
 
-		with_block_after(REPORTING_LOCK, || {
+		let dispute_id_2 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -566,25 +597,33 @@ fn get_disputes_by_reporter() {
 				query_data.clone(),
 			));
 
-			assert_eq!(Tellor::get_disputes_by_reporter(reporter), vec![1]);
+			assert_eq!(Tellor::get_disputes_by_reporter(reporter), vec![dispute_id]);
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_initiator),
 				query_id,
 				now()
 			));
-			assert_eq!(Tellor::get_disputes_by_reporter(reporter), vec![2, 1]);
+			let dispute_id_2 = super::dispute_id(PARA_ID, query_id, now());
+			assert_eq!(
+				sort(Tellor::get_disputes_by_reporter(reporter)),
+				sort(vec![dispute_id, dispute_id_2])
+			);
+			dispute_id_2
 		});
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(1));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
 		});
 
-		assert_eq!(Tellor::get_disputes_by_reporter(reporter), vec![2, 1]);
+		assert_eq!(
+			sort(Tellor::get_disputes_by_reporter(reporter)),
+			sort(vec![dispute_id, dispute_id_2])
+		);
 	});
 }
 
@@ -617,7 +656,7 @@ fn get_open_disputes_on_id() {
 			));
 			now()
 		});
-		with_block(|| {
+		let dispute_id = with_block(|| {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				another_reporter,
@@ -637,15 +676,16 @@ fn get_open_disputes_on_id() {
 			assert_eq!(Tellor::get_open_disputes_on_id(query_id), 1);
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			assert_eq!(Tellor::get_open_disputes_on_id(query_id), 2);
+			dispute_id(PARA_ID, query_id, now())
 		});
 
 		// Tally votes after vote duration
 		with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::tally_votes(1));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
 		});
 
 		assert_eq!(Tellor::get_open_disputes_on_id(query_id), 1);
@@ -664,7 +704,7 @@ fn get_vote_count() {
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L298
 	ext.execute_with(|| {
-		with_block(|| {
+		let dispute_id = with_block(|| {
 			assert_eq!(Tellor::get_vote_count(), 0, "vote count should start at 0");
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
@@ -681,15 +721,16 @@ fn get_vote_count() {
 			));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			assert_eq!(Tellor::get_vote_count(), 1, "vote count should increment correctly");
+			dispute_id(PARA_ID, query_id, now())
 		});
 
 		// Tally votes after vote duration
 		with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::tally_votes(1));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
 			assert_eq!(
 				Tellor::get_vote_count(),
 				1,
@@ -720,7 +761,7 @@ fn get_vote_info() {
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L322
 	ext.execute_with(|| {
-		let (disputed_time, disputed_block) = with_block(|| {
+		let (disputed_time, disputed_block, dispute_id) = with_block(|| {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
@@ -735,19 +776,20 @@ fn get_vote_info() {
 				query_data.clone(),
 			));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
-			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), 1, Some(true)));
-			(now(), System::block_number())
+			let dispute_id = dispute_id(PARA_ID, query_id, now());
+			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), dispute_id, Some(true)));
+			(now(), System::block_number(), dispute_id)
 		});
 
 		// Tally votes after vote duration
 		let tallied = with_block_after(86_400 * 7, || {
-			assert_ok!(Tellor::tally_votes(1));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 			now()
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
-			let vote = Tellor::get_vote_info(1).unwrap();
+			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
+			let vote = Tellor::get_vote_info(dispute_id, 1).unwrap();
 			let parachain_id: u32 = ParachainId::get();
 			assert_eq!(
 				vote.identifier,
@@ -795,7 +837,7 @@ fn get_vote_rounds() {
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L361
 	ext.execute_with(|| {
-		let (timestamp, identifier) = with_block(|| {
+		let (timestamp, dispute_id) = with_block(|| {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
@@ -810,21 +852,15 @@ fn get_vote_rounds() {
 				query_data.clone(),
 			));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
-			let parachain_id: u32 = ParachainId::get();
-			let identifier = keccak_256(&ethabi::encode(&vec![
-				Token::Uint(parachain_id.into()),
-				Token::FixedBytes(query_id.0.to_vec()),
-				Token::Uint(now().into()),
-			]))
-			.into();
-			assert_eq!(Tellor::get_vote_rounds(identifier), vec![1]);
-			(now(), identifier)
+			let dispute_id = dispute_id(PARA_ID, query_id, now());
+			assert_eq!(Tellor::get_vote_rounds(dispute_id), 1);
+			(now(), dispute_id)
 		});
 
 		with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::tally_votes(1));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, timestamp));
-			assert_eq!(Tellor::get_vote_rounds(identifier), vec![1, 2]);
+			assert_eq!(Tellor::get_vote_rounds(dispute_id), 2);
 		});
 	});
 }
@@ -842,7 +878,7 @@ fn get_vote_tally_by_address() {
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L383
 	ext.execute_with(|| {
-		with_block(|| {
+		let dispute_id = with_block(|| {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
@@ -857,6 +893,7 @@ fn get_vote_tally_by_address() {
 				query_data.clone(),
 			));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
+			dispute_id(PARA_ID, query_id, now())
 		});
 
 		with_block(|| {
@@ -874,19 +911,20 @@ fn get_vote_tally_by_address() {
 				query_data.clone(),
 			));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
+			let dispute_id_2 = super::dispute_id(PARA_ID, query_id, now());
 
 			assert_eq!(
 				Tellor::get_vote_tally_by_address(reporter),
 				0,
 				"vote tally should be correct"
 			);
-			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), 1, Some(false)));
+			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), dispute_id, Some(false)));
 			assert_eq!(
 				Tellor::get_vote_tally_by_address(reporter),
 				1,
 				"vote tally should be correct"
 			);
-			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), 2, Some(false)));
+			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), dispute_id_2, Some(false)));
 			assert_eq!(
 				Tellor::get_vote_tally_by_address(reporter),
 				2,
@@ -909,7 +947,7 @@ fn get_tips_by_address() {
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L404
 	ext.execute_with(|| {
-		with_block(|| {
+		let dispute_id = with_block(|| {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
@@ -932,23 +970,30 @@ fn get_tips_by_address() {
 			));
 
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
-			assert_ok!(Tellor::vote(RuntimeOrigin::signed(user), 1, Some(true)));
+			let dispute_id = dispute_id(PARA_ID, query_id, now());
+			assert_ok!(Tellor::vote(RuntimeOrigin::signed(user), dispute_id, Some(true)));
+			dispute_id
 		});
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(1));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 			now()
 		});
 
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
 			assert_eq!(
-				Tellor::get_vote_info(1).unwrap().users,
+				Tellor::get_vote_info(dispute_id, 1).unwrap().users,
 				Tally::<AmountOf<Test>> { does_support: token(20), against: 0, invalid_query: 0 },
 				"vote users does_support weight should be based on tip total"
 			)
 		});
 	});
+}
+
+fn sort(mut disputes: Vec<DisputeIdOf<Test>>) -> Vec<DisputeIdOf<Test>> {
+	disputes.sort();
+	disputes
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,8 +3,7 @@ use crate::{
 	mock,
 	mock::*,
 	types::{
-		AccountIdOf, Address, Amount, AmountOf, DisputeIdOf, QueryDataOf, QueryId, Timestamp,
-		ValueOf,
+		AccountIdOf, Address, Amount, AmountOf, DisputeId, QueryDataOf, QueryId, Timestamp, ValueOf,
 	},
 	xcm::{ethereum_xcm, XcmConfig},
 	Event, Origin, StakeAmount,
@@ -26,13 +25,13 @@ type Config = crate::types::Configuration;
 type Configuration = crate::pallet::Configuration<Test>;
 type Error = crate::Error<Test>;
 
-fn dispute_id(para_id: u32, query_id: QueryId, timestamp: Timestamp) -> DisputeIdOf<T> {
+fn dispute_id(para_id: u32, query_id: QueryId, timestamp: Timestamp) -> DisputeId {
 	keccak_256(&ethabi::encode(&[
 		Token::Uint(para_id.into()),
 		Token::FixedBytes(query_id.0.to_vec()),
 		Token::Uint(timestamp.into()),
 	]))
-		.into()
+	.into()
 }
 
 // Returns the timestamp for the current block.
@@ -44,7 +43,7 @@ fn submit_value_and_begin_dispute(
 	reporter: AccountIdOf<Test>,
 	query_id: QueryId,
 	query_data: QueryDataOf<Test>,
-) -> DisputeIdOf<Test> {
+) -> DisputeId {
 	assert_ok!(Tellor::submit_value(
 		RuntimeOrigin::signed(reporter),
 		query_id,

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-	constants::{DAYS, REPORTING_LOCK},
+	constants::REPORTING_LOCK,
 	types::{Nonce, QueryId, Timestamp},
 	Config,
 };

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -273,7 +273,13 @@ fn slash_reporter() {
 	ext.execute_with(|| {
 		let dispute_id = with_block(|| {
 			assert_noop!(
-				Tellor::report_slash(RuntimeOrigin::signed(reporter), 0, 0, 0, STAKE_AMOUNT.into()),
+				Tellor::report_slash(
+					RuntimeOrigin::signed(reporter),
+					H256::zero(),
+					0,
+					0,
+					STAKE_AMOUNT.into()
+				),
 				BadOrigin
 			);
 
@@ -289,7 +295,7 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 		});
 
 		// Report slash after tally dispute period
@@ -333,7 +339,7 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 		});
 
 		// Report slash after tally dispute period
@@ -370,7 +376,7 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 		});
 
 		// Report slash after tally dispute period
@@ -432,7 +438,7 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id));
+			assert_ok!(Tellor::tally_votes(dispute_id, 1));
 		});
 
 		// Report slash after tally dispute period

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,7 @@ pub type Address = H160;
 pub(crate) type Amount = U256;
 pub(crate) type AmountOf<T> = <T as Config>::Amount;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
-pub(crate) type DisputeIdOf<T> = <T as Config>::DisputeId;
+pub(crate) type DisputeIdOf<T> = <T as Config>::Hash;
 pub(crate) type DisputeOf<T> = governance::Dispute<AccountIdOf<T>, QueryId, Timestamp, ValueOf<T>>;
 pub(crate) type FeedId = H256;
 pub(crate) type FeedOf<T> = autopay::Feed<AmountOf<T>, Timestamp, <T as Config>::MaxRewardClaims>;
@@ -31,14 +31,12 @@ pub(crate) type StakeInfoOf<T> =
 pub(crate) type Timestamp = u64;
 pub(crate) type TipOf<T> = autopay::Tip<AmountOf<T>, Timestamp>;
 pub(crate) type ValueOf<T> = BoundedVec<u8, <T as Config>::MaxValueLength>;
-pub(crate) type VoteCountOf<T> = DisputeIdOf<T>;
-pub(crate) type VoteId = H256;
 pub(crate) type VoteOf<T> = governance::Vote<
 	AccountIdOf<T>,
 	AmountOf<T>,
 	BlockNumberOf<T>,
 	Timestamp,
-	VoteId,
+	DisputeIdOf<T>,
 	<T as Config>::MaxVotes,
 >;
 
@@ -197,9 +195,9 @@ pub(crate) mod governance {
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(MaxVotes))]
-	pub struct Vote<AccountId, Amount, BlockNumber, Timestamp, VoteId, MaxVotes: Get<u32>> {
-		/// Identifier of the vote.
-		pub identifier: VoteId,
+	pub struct Vote<AccountId, Amount, BlockNumber, Timestamp, DisputeId, MaxVotes: Get<u32>> {
+		/// Identifier of the dispute.
+		pub identifier: DisputeId,
 		/// The round of voting on a given dispute or proposal.
 		pub vote_round: u32,
 		/// Timestamp of when vote was initiated.

--- a/src/types.rs
+++ b/src/types.rs
@@ -199,7 +199,7 @@ pub(crate) mod governance {
 		/// Identifier of the dispute.
 		pub identifier: DisputeId,
 		/// The round of voting on a given dispute or proposal.
-		pub vote_round: u32,
+		pub vote_round: u8,
 		/// Timestamp of when vote was initiated.
 		pub start_date: Timestamp,
 		/// Block number of when vote was initiated.

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,7 @@ pub type Address = H160;
 pub(crate) type Amount = U256;
 pub(crate) type AmountOf<T> = <T as Config>::Amount;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
-pub(crate) type DisputeIdOf<T> = <T as Config>::Hash;
+pub(crate) type DisputeId = H256;
 pub(crate) type DisputeOf<T> = governance::Dispute<AccountIdOf<T>, QueryId, Timestamp, ValueOf<T>>;
 pub(crate) type FeedId = H256;
 pub(crate) type FeedOf<T> = autopay::Feed<AmountOf<T>, Timestamp, <T as Config>::MaxRewardClaims>;
@@ -36,7 +36,7 @@ pub(crate) type VoteOf<T> = governance::Vote<
 	AmountOf<T>,
 	BlockNumberOf<T>,
 	Timestamp,
-	DisputeIdOf<T>,
+	DisputeId,
 	<T as Config>::MaxVotes,
 >;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,50 +9,39 @@ pub type Address = H160;
 pub(crate) type Amount = U256;
 pub(crate) type AmountOf<T> = <T as Config>::Amount;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
-pub(crate) type DisputeId = H256;
-pub(crate) type DisputeOf<T> = governance::Dispute<AccountIdOf<T>, QueryId, Timestamp, ValueOf<T>>;
-pub(crate) type FeedId = H256;
-pub(crate) type FeedOf<T> = autopay::Feed<AmountOf<T>, Timestamp, <T as Config>::MaxRewardClaims>;
-pub(crate) type FeedDetailsOf<T> = autopay::FeedDetails<AmountOf<T>, Timestamp>;
+pub type DisputeId = H256;
+pub(crate) type DisputeOf<T> = governance::Dispute<AccountIdOf<T>, ValueOf<T>>;
+pub type FeedId = H256;
+pub(crate) type FeedOf<T> = autopay::Feed<AmountOf<T>, <T as Config>::MaxRewardClaims>;
+pub(crate) type FeedDetailsOf<T> = autopay::FeedDetails<AmountOf<T>>;
 pub(crate) type Nonce = u128;
 pub(crate) type ParaId = u32;
 pub(crate) type PriceOf<T> = <T as Config>::Price;
 pub(crate) type QueryDataOf<T> = BoundedVec<u8, <T as Config>::MaxQueryDataLength>;
-pub(crate) type QueryId = H256;
-pub(crate) type ReportOf<T> = oracle::Report<
-	AccountIdOf<T>,
-	BlockNumberOf<T>,
-	Timestamp,
-	ValueOf<T>,
-	<T as Config>::MaxTimestamps,
->;
+pub type QueryId = H256;
+pub(crate) type ReportOf<T> =
+	oracle::Report<AccountIdOf<T>, BlockNumberOf<T>, ValueOf<T>, <T as Config>::MaxTimestamps>;
 pub(crate) type StakeInfoOf<T> =
-	oracle::StakeInfo<AmountOf<T>, <T as Config>::MaxQueriesPerReporter, QueryId, Timestamp>;
-pub(crate) type Timestamp = u64;
-pub(crate) type TipOf<T> = autopay::Tip<AmountOf<T>, Timestamp>;
+	oracle::StakeInfo<AmountOf<T>, <T as Config>::MaxQueriesPerReporter>;
+pub type Timestamp = u64;
+pub(crate) type TipOf<T> = autopay::Tip<AmountOf<T>>;
 pub(crate) type ValueOf<T> = BoundedVec<u8, <T as Config>::MaxValueLength>;
-pub(crate) type VoteOf<T> = governance::Vote<
-	AccountIdOf<T>,
-	AmountOf<T>,
-	BlockNumberOf<T>,
-	Timestamp,
-	DisputeId,
-	<T as Config>::MaxVotes,
->;
+pub(crate) type VoteOf<T> =
+	governance::Vote<AccountIdOf<T>, AmountOf<T>, BlockNumberOf<T>, <T as Config>::MaxVotes>;
 
 pub(crate) mod autopay {
 	use super::*;
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(MaxRewardClaims))]
-	pub struct Feed<Amount, Timestamp, MaxRewardClaims: Get<u32>> {
-		pub(crate) details: FeedDetails<Amount, Timestamp>,
+	pub struct Feed<Amount, MaxRewardClaims: Get<u32>> {
+		pub(crate) details: FeedDetails<Amount>,
 		/// Tracks which tips were already paid out.
 		pub(crate) reward_claimed: BoundedBTreeMap<Timestamp, bool, MaxRewardClaims>,
 	}
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-	pub struct FeedDetails<Amount, Timestamp> {
+	pub struct FeedDetails<Amount> {
 		/// Amount paid for each eligible data submission.
 		pub(crate) reward: Amount,
 		/// Account remaining balance.
@@ -72,7 +61,7 @@ pub(crate) mod autopay {
 	}
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-	pub struct Tip<Amount, Timestamp> {
+	pub struct Tip<Amount> {
 		/// Amount tipped.
 		pub(crate) amount: Amount,
 		/// Time tipped.
@@ -87,7 +76,7 @@ pub(crate) mod oracle {
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(MaxTimestamps))]
-	pub struct Report<AccountId, BlockNumber, Timestamp, Value, MaxTimestamps: Get<u32>> {
+	pub struct Report<AccountId, BlockNumber, Value, MaxTimestamps: Get<u32>> {
 		/// All timestamps reported.
 		pub(crate) timestamps: BoundedVec<Timestamp, MaxTimestamps>,
 		/// Mapping of timestamps to respective indices.
@@ -103,8 +92,8 @@ pub(crate) mod oracle {
 		pub(crate) is_disputed: BoundedBTreeMap<Timestamp, bool, MaxTimestamps>,
 	}
 
-	impl<AccountId, BlockNumber, Timestamp: Ord, Value, MaxTimestamps: Get<u32>>
-		Report<AccountId, BlockNumber, Timestamp, Value, MaxTimestamps>
+	impl<AccountId, BlockNumber, Value, MaxTimestamps: Get<u32>>
+		Report<AccountId, BlockNumber, Value, MaxTimestamps>
 	{
 		pub(crate) fn new() -> Self {
 			Report {
@@ -120,7 +109,7 @@ pub(crate) mod oracle {
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(MaxQueries))]
-	pub struct StakeInfo<Amount, MaxQueries: Get<u32>, QueryId, Timestamp> {
+	pub struct StakeInfo<Amount, MaxQueries: Get<u32>> {
 		/// The address on the staking chain.
 		pub(crate) address: Address,
 		/// Stake or withdrawal request start date.
@@ -145,9 +134,7 @@ pub(crate) mod oracle {
 		pub(crate) reports_submitted_by_query_id: BoundedBTreeMap<QueryId, u128, MaxQueries>,
 	}
 
-	impl<Amount: Default, MaxQueries: Get<u32>, QueryId: Ord, Timestamp: Default>
-		StakeInfo<Amount, MaxQueries, QueryId, Timestamp>
-	{
+	impl<Amount: Default, MaxQueries: Get<u32>> StakeInfo<Amount, MaxQueries> {
 		pub(crate) fn new(address: Address) -> Self {
 			Self {
 				address,
@@ -170,7 +157,7 @@ pub(crate) mod governance {
 	use super::*;
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-	pub struct Dispute<AccountId, QueryId, Timestamp, Value> {
+	pub struct Dispute<AccountId, Value> {
 		/// Query identifier of disputed value
 		pub(crate) query_id: QueryId,
 		/// Timestamp of disputed value.
@@ -195,7 +182,7 @@ pub(crate) mod governance {
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(MaxVotes))]
-	pub struct Vote<AccountId, Amount, BlockNumber, Timestamp, DisputeId, MaxVotes: Get<u32>> {
+	pub struct Vote<AccountId, Amount, BlockNumber, MaxVotes: Get<u32>> {
 		/// Identifier of the dispute.
 		pub identifier: DisputeId,
 		/// The round of voting on a given dispute or proposal.


### PR DESCRIPTION
Proposed changes to standardise on `dispute_id` as hash as per parachain contracts, with incrementing vote rounds per `dispute_id`.