### PR TITLE
fix: convert non-configurable items

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -6,7 +6,6 @@ use crate::{
 use codec::Encode;
 use frame_support::{
 	parameter_types,
-	sp_runtime::traits::Keccak256,
 	traits::{ConstU16, ConstU64},
 	BoundedVec, PalletId,
 };
@@ -100,14 +99,10 @@ impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type Amount = Amount;
-	type ClaimBuffer = ();
-	type ClaimPeriod = ();
 	type DisputeId = DisputeId;
 	type Fee = ();
 	type Governance = ();
 	type GovernanceOrigin = EnsureGovernance;
-	type Hash = H256;
-	type Hasher = Keccak256;
 	type MaxClaimTimestamps = ();
 	type MaxFeedsPerQuery = ();
 	type MaxFundedFeeds = ();
@@ -124,15 +119,11 @@ impl tellor::Config for Test {
 	type Price = u32;
 	type RegistrationOrigin = frame_system::EnsureRoot<AccountId>;
 	type Registry = ();
-	type ReportingLock = ConstU64<42>;
 	type Staking = ();
 	type StakingOrigin = EnsureStaking;
 	type Time = Timestamp;
 	type Token = Balances;
 	type ValueConverter = ();
-	type VoteRoundPeriod = ();
-	type VoteTallyDisputePeriod = ();
-	type WithdrawalPeriod = ();
 	type Xcm = TestSendXcm;
 }
 pub struct TestSendXcm;
@@ -575,7 +566,7 @@ mod oracle {
 	#[test]
 	fn get_reporting_lock() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(Test.get_reporting_lock(&BLOCKID).unwrap(), 42);
+			assert_eq!(Test.get_reporting_lock(&BLOCKID).unwrap(), 43200);
 		});
 	}
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,24 @@
+use crate::types::Timestamp;
+
+const MINUTE_IN_SECONDS: Timestamp = 60;
+pub(crate) const HOUR_IN_SECONDS: Timestamp = 60 * MINUTE_IN_SECONDS;
+pub(crate) const DAY_IN_SECONDS: Timestamp = 24 * HOUR_IN_SECONDS;
+pub(crate) const WEEK_IN_SECONDS: Timestamp = 7 * DAY_IN_SECONDS;
+
+/// The claim buffer time.
+pub(crate) const CLAIM_BUFFER: Timestamp = 12 * HOUR_IN_SECONDS;
+
+/// The claim period.
+pub(crate) const CLAIM_PERIOD: Timestamp = 4 * WEEK_IN_SECONDS;
+
+/// The dispute period.
+pub(crate) const DISPUTE_PERIOD: Timestamp = 1 * DAY_IN_SECONDS;
+
+/// Base amount of time before a reporter is able to submit a value again.
+pub(crate) const REPORTING_LOCK: Timestamp = 12 * HOUR_IN_SECONDS;
+
+/// The dispute period after a vote has been tallied.
+pub(crate) const TALLIED_VOTE_DISPUTE_PERIOD: Timestamp = 1 * DAY_IN_SECONDS;
+
+/// The withdrawal period.
+pub(crate) const WITHDRAWAL_PERIOD: Timestamp = 7 * DAY_IN_SECONDS;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,24 +1,9 @@
 use crate::types::Timestamp;
 
-const MINUTE_IN_SECONDS: Timestamp = 60;
-pub(crate) const HOUR_IN_SECONDS: Timestamp = 60 * MINUTE_IN_SECONDS;
-pub(crate) const DAY_IN_SECONDS: Timestamp = 24 * HOUR_IN_SECONDS;
-pub(crate) const WEEK_IN_SECONDS: Timestamp = 7 * DAY_IN_SECONDS;
-
-/// The claim buffer time.
-pub(crate) const CLAIM_BUFFER: Timestamp = 12 * HOUR_IN_SECONDS;
-
-/// The claim period.
-pub(crate) const CLAIM_PERIOD: Timestamp = 4 * WEEK_IN_SECONDS;
-
-/// The dispute period.
-pub(crate) const DISPUTE_PERIOD: Timestamp = 1 * DAY_IN_SECONDS;
+const MINUTES: Timestamp = 60;
+pub(crate) const HOURS: Timestamp = 60 * MINUTES;
+pub(crate) const DAYS: Timestamp = 24 * HOURS;
+pub(crate) const WEEKS: Timestamp = 7 * DAYS;
 
 /// Base amount of time before a reporter is able to submit a value again.
-pub(crate) const REPORTING_LOCK: Timestamp = 12 * HOUR_IN_SECONDS;
-
-/// The dispute period after a vote has been tallied.
-pub(crate) const TALLIED_VOTE_DISPUTE_PERIOD: Timestamp = 1 * DAY_IN_SECONDS;
-
-/// The withdrawal period.
-pub(crate) const WITHDRAWAL_PERIOD: Timestamp = 7 * DAY_IN_SECONDS;
+pub(crate) const REPORTING_LOCK: Timestamp = 12 * HOURS;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -71,8 +71,8 @@ impl<T: Config> Pallet<T> {
 
 	pub(super) fn _fund_feed(
 		feed_funder: AccountIdOf<T>,
-		feed_id: FeedIdOf<T>,
-		query_id: QueryIdOf<T>,
+		feed_id: FeedId,
+		query_id: QueryId,
 		amount: AmountOf<T>,
 	) -> DispatchResult {
 		let Some(mut feed) = <DataFeeds<T>>::get(query_id, feed_id) else {
@@ -119,7 +119,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// Block number of the timestamp for the given query identifier and timestamp, if found.
 	pub fn get_block_number_by_timestamp(
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 		timestamp: Timestamp,
 	) -> Option<BlockNumberOf<T>> {
 		<Reports<T>>::get(query_id)
@@ -131,7 +131,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of reported data.
 	/// # Returns
 	/// Feed identifiers for query identifier.
-	pub fn get_current_feeds(query_id: QueryIdOf<T>) -> Vec<FeedIdOf<T>> {
+	pub fn get_current_feeds(query_id: QueryId) -> Vec<FeedId> {
 		<CurrentFeeds<T>>::get(query_id).map_or_else(Vec::default, |f| f.to_vec())
 	}
 
@@ -140,7 +140,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of reported data.
 	/// # Returns
 	/// Amount of tip.
-	pub fn get_current_tip(query_id: QueryIdOf<T>) -> AmountOf<T> {
+	pub fn get_current_tip(query_id: QueryId) -> AmountOf<T> {
 		// todo: optimise
 		// if no tips, return 0
 		if <Tips<T>>::get(query_id).map_or(0, |t| t.len()) == 0 {
@@ -161,7 +161,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier to look up the value for
 	/// # Returns
 	/// The value retrieved, along with its timestamp, if found.
-	pub(super) fn _get_current_value(query_id: QueryIdOf<T>) -> Option<(ValueOf<T>, Timestamp)> {
+	pub(super) fn _get_current_value(query_id: QueryId) -> Option<(ValueOf<T>, Timestamp)> {
 		let mut count = Self::get_new_value_count_by_query_id(query_id);
 		if count == 0 {
 			return None
@@ -185,7 +185,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - The identifier of the specific data feed.
 	/// # Returns
 	/// The latest submitted value for the given identifier.
-	pub fn get_current_value(query_id: QueryIdOf<T>) -> Option<ValueOf<T>> {
+	pub fn get_current_value(query_id: QueryId) -> Option<ValueOf<T>> {
 		// todo: implement properly
 		<Reports<T>>::get(query_id)
 			.and_then(|r| r.value_by_timestamp.last_key_value().map(|kv| kv.1.clone()))
@@ -198,7 +198,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// The value retrieved and its timestamp, if found.
 	pub fn get_data_before(
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 		timestamp: Timestamp,
 	) -> Option<(ValueOf<T>, Timestamp)> {
 		Self::get_index_for_data_before(query_id, timestamp)
@@ -214,7 +214,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Unique feed identifier of parameters.
 	/// # Returns
 	/// Details of the specified feed.
-	pub fn get_data_feed(feed_id: FeedIdOf<T>) -> Option<FeedDetailsOf<T>> {
+	pub fn get_data_feed(feed_id: FeedId) -> Option<FeedDetailsOf<T>> {
 		<QueryIdFromDataFeedId<T>>::get(feed_id)
 			.and_then(|query_id| <DataFeeds<T>>::get(query_id, feed_id))
 			.map(|f| f.details)
@@ -237,7 +237,7 @@ impl<T: Config> Pallet<T> {
 	/// reporter of the disputed value.
 	pub fn get_dispute_info(
 		dispute_id: DisputeIdOf<T>,
-	) -> Option<(QueryIdOf<T>, Timestamp, ValueOf<T>, AccountIdOf<T>)> {
+	) -> Option<(QueryId, Timestamp, ValueOf<T>, AccountIdOf<T>)> {
 		<DisputeInfo<T>>::get(dispute_id)
 			.map(|d| (d.query_id, d.timestamp, d.value, d.disputed_reporter))
 	}
@@ -270,14 +270,14 @@ impl<T: Config> Pallet<T> {
 	/// Read currently funded feeds.
 	/// # Returns
 	/// The currently funded feeds
-	pub fn get_funded_feeds() -> Vec<FeedIdOf<T>> {
+	pub fn get_funded_feeds() -> Vec<FeedId> {
 		<FeedsWithFunding<T>>::get().to_vec()
 	}
 
 	/// Read query identifiers with current one-time tips.
 	/// # Returns
 	/// Query identifiers with current one-time tips.
-	pub fn get_funded_query_ids() -> Vec<QueryIdOf<T>> {
+	pub fn get_funded_query_ids() -> Vec<QueryId> {
 		<QueryIdsWithFunding<T>>::get().to_vec()
 	}
 
@@ -300,10 +300,7 @@ impl<T: Config> Pallet<T> {
 	/// * `timestamp` - The timestamp before which to search for the latest index.
 	/// # Returns
 	/// Whether the index was found along with the latest index found before the supplied timestamp.
-	pub fn get_index_for_data_before(
-		query_id: QueryIdOf<T>,
-		timestamp: Timestamp,
-	) -> Option<usize> {
+	pub fn get_index_for_data_before(query_id: QueryId, timestamp: Timestamp) -> Option<usize> {
 		let count = Self::get_new_value_count_by_query_id(query_id);
 		if count > 0 {
 			let mut middle;
@@ -395,7 +392,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// Amount of tip.
 	pub(super) fn get_onetime_tip_amount(
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 		timestamp: Timestamp,
 		claimer: &AccountIdOf<T>,
 	) -> Result<AmountOf<T>, Error<T>> {
@@ -498,7 +495,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of a specific data feed.
 	/// # Returns
 	/// The number of open disputes for the query identifier.
-	pub fn get_open_disputes_on_id(query_id: QueryIdOf<T>) -> u128 {
+	pub fn get_open_disputes_on_id(query_id: QueryId) -> u128 {
 		<OpenDisputesOnId<T>>::get(query_id).unwrap_or_default()
 	}
 
@@ -507,7 +504,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of reported data.
 	/// # Returns
 	/// The number of past tips.
-	pub fn get_past_tip_count(query_id: QueryIdOf<T>) -> u32 {
+	pub fn get_past_tip_count(query_id: QueryId) -> u32 {
 		<Tips<T>>::get(query_id).map_or(0, |t| t.len() as u32)
 	}
 
@@ -516,7 +513,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of reported data.
 	/// # Returns
 	/// All past tips.
-	pub fn get_past_tips(query_id: QueryIdOf<T>) -> Vec<Tip<AmountOf<T>, Timestamp>> {
+	pub fn get_past_tips(query_id: QueryId) -> Vec<Tip<AmountOf<T>, Timestamp>> {
 		<Tips<T>>::get(query_id).map_or_else(Vec::default, |t| t.to_vec())
 	}
 
@@ -527,13 +524,13 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// The past tip, if found.
 	pub fn get_past_tip_by_index(
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 		index: u32,
 	) -> Option<Tip<AmountOf<T>, Timestamp>> {
 		<Tips<T>>::get(query_id).and_then(|t| t.get(index as usize).cloned())
 	}
 
-	pub fn get_query_data(query_id: QueryIdOf<T>) -> Option<QueryDataOf<T>> {
+	pub fn get_query_data(query_id: QueryId) -> Option<QueryDataOf<T>> {
 		<QueryData<T>>::get(query_id)
 	}
 
@@ -542,7 +539,7 @@ impl<T: Config> Pallet<T> {
 	/// * `feed_id` - Data feed unique identifier.
 	/// # Returns
 	/// Corresponding query identifier, if found.
-	pub fn get_query_id_from_feed_id(feed_id: FeedIdOf<T>) -> Option<QueryIdOf<T>> {
+	pub fn get_query_id_from_feed_id(feed_id: FeedId) -> Option<QueryId> {
 		<QueryIdFromDataFeedId<T>>::get(feed_id)
 	}
 
@@ -553,7 +550,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// The reporter who submitted the value and whether the value was disputed, provided a value exists.
 	pub fn get_report_details(
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 		timestamp: Timestamp,
 	) -> Option<(AccountIdOf<T>, bool)> {
 		<Reports<T>>::get(query_id).and_then(|report| {
@@ -570,7 +567,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// Identifier of the reporter who reported the value for the query identifier at the given timestamp.
 	pub fn get_reporter_by_timestamp(
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 		timestamp: Timestamp,
 	) -> Option<AccountIdOf<T>> {
 		<Reports<T>>::get(query_id)
@@ -612,7 +609,7 @@ impl<T: Config> Pallet<T> {
 	/// The number of values submitted by the given reporter to the given query identifier.
 	pub fn get_reports_submitted_by_address_and_query_id(
 		reporter: AccountIdOf<T>,
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 	) -> u128 {
 		<StakerDetails<T>>::get(reporter)
 			.and_then(|stake_info| stake_info.reports_submitted_by_query_id.get(&query_id).copied())
@@ -620,8 +617,8 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub(super) fn _get_reward_amount(
-		feed_id: FeedIdOf<T>,
-		query_id: QueryIdOf<T>,
+		feed_id: FeedId,
+		query_id: QueryId,
 		timestamp: Timestamp,
 	) -> Result<AmountOf<T>, Error<T>> {
 		ensure!(
@@ -685,8 +682,8 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// Potential reward for a set of oracle submissions.
 	pub fn get_reward_amount(
-		feed_id: FeedIdOf<T>,
-		query_id: QueryIdOf<T>,
+		feed_id: FeedId,
+		query_id: QueryId,
 		timestamps: Vec<Timestamp>,
 	) -> AmountOf<T> {
 		// todo: use boundedvec for timestamps
@@ -715,8 +712,8 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// Whether a reward has been claimed, if timestamp exists.
 	pub fn get_reward_claimed_status(
-		feed_id: FeedIdOf<T>,
-		query_id: QueryIdOf<T>,
+		feed_id: FeedId,
+		query_id: QueryId,
 		timestamp: Timestamp,
 	) -> Option<bool> {
 		<DataFeeds<T>>::get(query_id, feed_id)
@@ -731,8 +728,8 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// Whether rewards have been claimed.
 	pub fn get_reward_claim_status_list(
-		feed_id: FeedIdOf<T>,
-		query_id: QueryIdOf<T>,
+		feed_id: FeedId,
+		query_id: QueryId,
 		timestamps: Vec<Timestamp>,
 	) -> Vec<bool> {
 		// todo: use boundedvec for timestamps
@@ -774,7 +771,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// A timestamp if found.
 	pub fn get_timestamp_by_query_id_and_index(
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 		index: usize,
 	) -> Option<Timestamp> {
 		<Reports<T>>::get(query_id).and_then(|report| report.timestamps.get(index).copied())
@@ -787,7 +784,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// The index of the reporter timestamp within the available timestamps for specific query identifier.
 	pub fn get_timestamp_index_by_timestamp(
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 		timestamp: Timestamp,
 	) -> Option<u32> {
 		<Reports<T>>::get(query_id)
@@ -822,7 +819,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - The query identifier to look up.
 	/// # Returns
 	/// Count of the number of values received for the query identifier.
-	pub fn get_new_value_count_by_query_id(query_id: QueryIdOf<T>) -> usize {
+	pub fn get_new_value_count_by_query_id(query_id: QueryId) -> usize {
 		<Reports<T>>::get(query_id).map_or(usize::default(), |r| r.timestamps.len())
 	}
 
@@ -848,7 +845,7 @@ impl<T: Config> Pallet<T> {
 	/// * `vote_id` - Identifier for a vote.
 	/// # Returns
 	/// Dispute identifiers of the vote rounds.
-	pub fn get_vote_rounds(vote_id: VoteIdOf<T>) -> Vec<DisputeIdOf<T>> {
+	pub fn get_vote_rounds(vote_id: VoteId) -> Vec<DisputeIdOf<T>> {
 		<VoteRounds<T>>::get(vote_id).into_inner()
 	}
 
@@ -867,7 +864,7 @@ impl<T: Config> Pallet<T> {
 	/// * `timestamp` - Timestamp of the value.
 	/// # Returns
 	/// Whether the value is disputed.
-	pub fn is_in_dispute(query_id: QueryIdOf<T>, timestamp: Timestamp) -> bool {
+	pub fn is_in_dispute(query_id: QueryId, timestamp: Timestamp) -> bool {
 		<Reports<T>>::get(query_id)
 			.map_or(false, |report| report.is_disputed.contains_key(&timestamp))
 	}
@@ -882,7 +879,7 @@ impl<T: Config> Pallet<T> {
 	/// # Arguments
 	/// * `query_id` - Identifier of the specific data feed.
 	/// * `timestamp` - The timestamp of the value to remove.
-	pub(super) fn remove_value(query_id: QueryIdOf<T>, timestamp: Timestamp) -> DispatchResult {
+	pub(super) fn remove_value(query_id: QueryId, timestamp: Timestamp) -> DispatchResult {
 		// todo: rename once remove_value dispatchable removed
 		<Reports<T>>::mutate(query_id, |maybe| match maybe {
 			None => Err(Error::<T>::InvalidTimestamp),
@@ -915,12 +912,12 @@ impl<T: Config> Pallet<T> {
 	/// * `timestamp` - Timestamp to retrieve data/value from.
 	/// # Returns
 	/// Value for timestamp submitted, if found.
-	pub fn retrieve_data(query_id: QueryIdOf<T>, timestamp: Timestamp) -> Option<ValueOf<T>> {
+	pub fn retrieve_data(query_id: QueryId, timestamp: Timestamp) -> Option<ValueOf<T>> {
 		<Reports<T>>::get(query_id)
 			.and_then(|report| report.value_by_timestamp.get(&timestamp).cloned())
 	}
 
-	pub(super) fn store_data(query_id: QueryIdOf<T>, query_data: &QueryDataOf<T>) {
+	pub(super) fn store_data(query_id: QueryId, query_data: &QueryDataOf<T>) {
 		QueryData::<T>::insert(query_id, query_data);
 		Self::deposit_event(Event::QueryDataStored { query_id });
 	}
@@ -1042,11 +1039,8 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-impl<T: Config> UsingTellor<AccountIdOf<T>, PriceOf<T>, QueryIdOf<T>> for Pallet<T> {
-	fn get_data_after(
-		query_id: QueryIdOf<T>,
-		timestamp: Timestamp,
-	) -> Option<(Vec<u8>, Timestamp)> {
+impl<T: Config> UsingTellor<AccountIdOf<T>, PriceOf<T>> for Pallet<T> {
+	fn get_data_after(query_id: QueryId, timestamp: Timestamp) -> Option<(Vec<u8>, Timestamp)> {
 		Self::get_index_for_data_after(query_id, timestamp)
 			.and_then(|index| Self::get_timestamp_by_query_id_and_index(query_id, index))
 			.and_then(|timestamp_retrieved| {
@@ -1055,52 +1049,46 @@ impl<T: Config> UsingTellor<AccountIdOf<T>, PriceOf<T>, QueryIdOf<T>> for Pallet
 			})
 	}
 
-	fn get_data_before(
-		query_id: QueryIdOf<T>,
-		timestamp: Timestamp,
-	) -> Option<(Vec<u8>, Timestamp)> {
+	fn get_data_before(query_id: QueryId, timestamp: Timestamp) -> Option<(Vec<u8>, Timestamp)> {
 		Self::get_data_before(query_id, timestamp).map(|(v, t)| (v.into_inner(), t))
 	}
 
-	fn get_index_for_data_after(_query_id: QueryIdOf<T>, _timestamp: Timestamp) -> Option<usize> {
+	fn get_index_for_data_after(_query_id: QueryId, _timestamp: Timestamp) -> Option<usize> {
 		todo!()
 	}
 
-	fn get_index_for_data_before(query_id: QueryIdOf<T>, timestamp: Timestamp) -> Option<usize> {
+	fn get_index_for_data_before(query_id: QueryId, timestamp: Timestamp) -> Option<usize> {
 		Self::get_index_for_data_before(query_id, timestamp)
 	}
 
 	fn get_multiple_values_before(
-		_query_id: QueryIdOf<T>,
+		_query_id: QueryId,
 		_timestamp: Timestamp,
 		_max_age: Timestamp,
 	) -> Vec<(Vec<u8>, Timestamp)> {
 		todo!()
 	}
 
-	fn get_new_value_count_by_query_id(query_id: QueryIdOf<T>) -> usize {
+	fn get_new_value_count_by_query_id(query_id: QueryId) -> usize {
 		Self::get_new_value_count_by_query_id(query_id)
 	}
 
 	fn get_reporter_by_timestamp(
-		query_id: QueryIdOf<T>,
+		query_id: QueryId,
 		timestamp: Timestamp,
 	) -> Option<AccountIdOf<T>> {
 		Self::get_reporter_by_timestamp(query_id, timestamp)
 	}
 
-	fn get_timestamp_by_query_id_and_index(
-		query_id: QueryIdOf<T>,
-		index: usize,
-	) -> Option<Timestamp> {
+	fn get_timestamp_by_query_id_and_index(query_id: QueryId, index: usize) -> Option<Timestamp> {
 		Self::get_timestamp_by_query_id_and_index(query_id, index)
 	}
 
-	fn is_in_dispute(query_id: QueryIdOf<T>, timestamp: Timestamp) -> bool {
+	fn is_in_dispute(query_id: QueryId, timestamp: Timestamp) -> bool {
 		Self::is_in_dispute(query_id, timestamp)
 	}
 
-	fn retrieve_data(query_id: QueryIdOf<T>, timestamp: Timestamp) -> Option<Vec<u8>> {
+	fn retrieve_data(query_id: QueryId, timestamp: Timestamp) -> Option<Vec<u8>> {
 		Self::retrieve_data(query_id, timestamp).map(|v| v.into_inner())
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use crate::constants::{
-	CLAIM_BUFFER, CLAIM_PERIOD, DISPUTE_PERIOD, REPORTING_LOCK, TALLIED_VOTE_DISPUTE_PERIOD,
-	WITHDRAWAL_PERIOD,
-};
+use crate::constants::{DAYS, HOURS, REPORTING_LOCK, WEEKS};
 pub use crate::xcm::{ContractLocation, LocationToAccount, LocationToOrigin};
 use codec::Encode;
 use frame_support::{
@@ -451,7 +448,7 @@ pub mod pallet {
 		AlreadyVoted,
 		/// Dispute must be started within reporting lock time.
 		DisputeReportingPeriodExpired,
-		/// New dispute round must be started within the dispute round reporting time.
+		/// New dispute round must be started within a day.
 		DisputeRoundReportingPeriodExpired,
 		/// Dispute does not exist.
 		InvalidDispute,
@@ -467,7 +464,7 @@ pub mod pallet {
 		NotReporter,
 		/// No value exists at given timestamp.
 		NoValueExists,
-		/// Sufficient time has to pass after tally to allow for disputes.
+		/// One day has to pass after tally to allow for disputes.
 		TallyDisputePeriodActive,
 		/// Vote has already been executed.
 		VoteAlreadyExecuted,
@@ -658,7 +655,7 @@ pub mod pallet {
 			let mut cumulative_reward = AmountOf::<T>::default();
 			for timestamp in &timestamps {
 				ensure!(
-					Self::now().saturating_sub(*timestamp) > CLAIM_BUFFER,
+					Self::now().saturating_sub(*timestamp) > 12 * HOURS,
 					Error::<T>::ClaimBufferNotPassed
 				);
 				ensure!(
@@ -1139,7 +1136,7 @@ pub mod pallet {
 				ensure!(
 					Self::now() -
 						<VoteInfo<T>>::get(prev_id).ok_or(Error::<T>::InvalidVote)?.tally_date <
-						DISPUTE_PERIOD,
+						1 * DAYS,
 					Error::<T>::DisputeRoundReportingPeriodExpired
 				);
 				vote.fee = vote.fee.saturating_mul(
@@ -1406,7 +1403,7 @@ pub mod pallet {
 							Error::<T>::NoWithdrawalRequested
 						);
 						ensure!(
-							Self::now().saturating_sub(staker.start_date) >= WITHDRAWAL_PERIOD,
+							Self::now().saturating_sub(staker.start_date) >= 7 * DAYS,
 							Error::<T>::WithdrawalPeriodPending
 						);
 						// toWithdraw -= _staker.lockedBalance; // todo: required?

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,13 +1,8 @@
 use crate as tellor;
-use crate::{
-	types::{Address, MomentOf},
-	xcm::ContractLocation,
-	EnsureGovernance, EnsureStaking, DAY_IN_MILLISECONDS, HOUR_IN_MILLISECONDS,
-	WEEK_IN_MILLISECONDS,
-};
+use crate::{types::Address, xcm::ContractLocation, EnsureGovernance, EnsureStaking};
 use frame_support::{
 	assert_ok, log, parameter_types,
-	traits::{ConstU16, ConstU64, OnFinalize},
+	traits::{ConstU16, ConstU64, OnFinalize, UnixTime},
 	PalletId,
 };
 use frame_system as system;
@@ -20,7 +15,7 @@ use sp_runtime::{
 use sp_std::cell::RefCell;
 use std::{
 	convert::Into,
-	time::{SystemTime, UNIX_EPOCH},
+	time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use xcm::latest::prelude::*;
 
@@ -110,8 +105,6 @@ impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type Amount = u64;
-	type ClaimBuffer = ConstU64<{ 12 * HOUR_IN_MILLISECONDS }>;
-	type ClaimPeriod = ConstU64<{ 4 * WEEK_IN_MILLISECONDS }>;
 	type DisputeId = u32;
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
@@ -134,15 +127,11 @@ impl tellor::Config for Test {
 	type Price = u128;
 	type RegistrationOrigin = system::EnsureRoot<AccountId>;
 	type Registry = TellorRegistry;
-	type ReportingLock = ConstU64<{ 12 * HOUR_IN_MILLISECONDS }>;
 	type Staking = TellorStaking;
 	type StakingOrigin = EnsureStaking;
 	type Time = Timestamp;
 	type Token = Balances;
 	type ValueConverter = ValueConverter;
-	type VoteRoundPeriod = ConstU64<{ 1 * DAY_IN_MILLISECONDS }>;
-	type VoteTallyDisputePeriod = ConstU64<{ 1 * DAY_IN_MILLISECONDS }>;
-	type WithdrawalPeriod = ConstU64<{ 7 * DAY_IN_MILLISECONDS }>;
 	type Xcm = TestSendXcm;
 }
 
@@ -196,7 +185,7 @@ pub(crate) fn with_block<R>(execute: impl FnOnce() -> R) -> R {
 }
 
 /// Starts a new block after some time, executing the supplied closure thereafter.
-pub(crate) fn with_block_after<R>(time: MomentOf<Test>, execute: impl FnOnce() -> R) -> R {
+pub(crate) fn with_block_after<R>(time_in_secs: u64, execute: impl FnOnce() -> R) -> R {
 	let block = System::block_number();
 	match block {
 		0 => {
@@ -212,7 +201,11 @@ pub(crate) fn with_block_after<R>(time: MomentOf<Test>, execute: impl FnOnce() -
 		_ => {
 			Timestamp::on_finalize(block);
 			System::set_block_number(block + 1);
-			assert_ok!(Timestamp::set(RuntimeOrigin::none(), Timestamp::get() + 1 + time));
+			assert_ok!(Timestamp::set(
+				RuntimeOrigin::none(),
+				(<Timestamp as UnixTime>::now() + Duration::from_secs(1 + time_in_secs)).as_millis()
+					as u64
+			));
 		},
 	}
 	execute()

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -10,7 +10,7 @@ use once_cell::sync::Lazy;
 use sp_core::{ConstU32, H256};
 use sp_runtime::{
 	testing::Header,
-	traits::{BlakeTwo256, Convert, IdentityLookup, Keccak256},
+	traits::{BlakeTwo256, Convert, IdentityLookup},
 };
 use sp_std::cell::RefCell;
 use std::{
@@ -109,8 +109,6 @@ impl tellor::Config for Test {
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;
-	type Hash = H256;
-	type Hasher = Keccak256;
 	type MaxClaimTimestamps = ConstU32<10>;
 	type MaxFeedsPerQuery = ConstU32<10>;
 	type MaxFundedFeeds = ConstU32<10>;

--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
 	constants::{CLAIM_BUFFER, REPORTING_LOCK, WEEK_IN_SECONDS},
-	types::{FeedDetailsOf, FeedIdOf, QueryDataOf, QueryIdOf, Timestamp, TipOf},
+	types::{FeedDetailsOf, FeedId, QueryDataOf, QueryId, Timestamp, TipOf},
 	Config,
 };
 use frame_support::{
@@ -2357,7 +2357,7 @@ fn get_current_feeds() {
 	new_test_ext().execute_with(|| {
 		with_block(|| {
 			// create multiple feeds for the same query id
-			let feeds: Vec<FeedIdOf<Test>> = (1..=5u8)
+			let feeds: Vec<FeedId> = (1..=5u8)
 				.map(|i| {
 					create_feed(
 						feed_creator,
@@ -2382,7 +2382,7 @@ fn get_current_feeds() {
 // Helper function for creating feeds
 fn create_feed(
 	feed_creator: AccountIdOf<Test>,
-	query_id: QueryIdOf<Test>,
+	query_id: QueryId,
 	reward: AmountOf<Test>,
 	start_time: Timestamp,
 	interval: Timestamp,
@@ -2391,7 +2391,7 @@ fn create_feed(
 	reward_increase_per_second: AmountOf<Test>,
 	query_data: QueryDataOf<Test>,
 	amount: AmountOf<Test>,
-) -> FeedIdOf<Test> {
+) -> FeedId {
 	assert_ok!(Tellor::setup_data_feed(
 		RuntimeOrigin::signed(feed_creator),
 		query_id,

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -1,14 +1,16 @@
 use super::*;
-use crate::{mock::AccountId, types::Tally, Config, VoteResult};
+use crate::{
+	constants::{DISPUTE_PERIOD, REPORTING_LOCK, TALLIED_VOTE_DISPUTE_PERIOD},
+	mock::AccountId,
+	types::Tally,
+	Config, VoteResult,
+};
 use frame_support::{assert_noop, assert_ok, traits::Currency};
-use sp_core::{bounded::BoundedBTreeMap, bounded_btree_map, Get};
+use sp_core::{bounded::BoundedBTreeMap, bounded_btree_map};
 use sp_runtime::traits::BadOrigin;
 
 type BoundedVotes = BoundedBTreeMap<AccountId, bool, <Test as Config>::MaxVotes>;
 type ParachainId = <Test as Config>::ParachainId;
-type ReportingLock = <Test as Config>::ReportingLock;
-type VoteRoundPeriod = <Test as Config>::VoteRoundPeriod;
-type VoteTallyDisputePeriod = <Test as Config>::VoteTallyDisputePeriod;
 
 #[test]
 fn begin_dispute() {
@@ -52,7 +54,7 @@ fn begin_dispute() {
 				0,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
 
 		let dispute_id = with_block(|| {
@@ -88,12 +90,11 @@ fn begin_dispute() {
 			dispute_id
 		});
 
-		let dispute_period = VoteRoundPeriod::get();
-		with_block_after(dispute_period, || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(dispute_id));
 		});
 
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::report_slash(
 				Origin::Governance.into(),
 				dispute_id,
@@ -103,7 +104,7 @@ fn begin_dispute() {
 			));
 		});
 
-		let timestamp = with_block_after(dispute_period * 2, || {
+		let timestamp = with_block_after(DISPUTE_PERIOD * 2, || {
 			assert_noop!(
 				Tellor::begin_dispute(RuntimeOrigin::signed(another_reporter), query_id, timestamp),
 				Error::DisputeRoundReportingPeriodExpired
@@ -122,10 +123,10 @@ fn begin_dispute() {
 				0,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_noop!(
 				Tellor::begin_dispute(RuntimeOrigin::signed(another_reporter), query_id, timestamp),
 				Error::DisputeReportingPeriodExpired
@@ -153,7 +154,7 @@ fn begins_dispute_xcm() {
 				query_data
 			));
 
-			let timestamp = Timestamp::now();
+			let timestamp = now();
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, timestamp));
 
 			let sent_messages = sent_xcm();
@@ -208,18 +209,18 @@ fn execute_vote() {
 			));
 			// todo
 			// assert_noop!(
-			// 	Tellor::begin_dispute(RuntimeOrigin::signed(4), query_id, Timestamp::get()),
+			// 	Tellor::begin_dispute(RuntimeOrigin::signed(4), query_id, now()),
 			// 	pallet_balances::Error::<Test>::InsufficientBalance
 			// ); // must have tokens to pay for dispute
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_reporter),
 				query_id,
-				Timestamp::get()
+				now()
 			));
 			//let balance_2 = Balances::balance(&dispute_reporter);
 			assert_eq!(
 				Tellor::get_dispute_info(1).unwrap(),
-				(query_id, Timestamp::get(), uint_value(100), reporter_1)
+				(query_id, now(), uint_value(100), reporter_1)
 			);
 			assert_eq!(
 				Tellor::get_open_disputes_on_id(query_id),
@@ -230,7 +231,7 @@ fn execute_vote() {
 			let identifier = keccak_256(&ethabi::encode(&vec![
 				Token::Uint(parachain_id.into()),
 				Token::FixedBytes(query_id.0.to_vec()),
-				Token::Uint(Timestamp::get().into()),
+				Token::Uint(now().into()),
 			]))
 			.into();
 			assert_eq!(
@@ -242,15 +243,15 @@ fn execute_vote() {
 
 			assert_noop!(Tellor::execute_vote(10, result), Error::InvalidDispute); // dispute id must exist
 			assert_noop!(Tellor::execute_vote(1, result), Error::VoteNotTallied); // vote must be tallied
-			(Timestamp::get(), identifier)
+			(now(), identifier)
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(1));
 			assert_noop!(Tellor::execute_vote(1, result), Error::TallyDisputePeriodActive); // a day must pass before execution
 		});
 
-		let timestamp = with_block_after(VoteTallyDisputePeriod::get(), || {
+		let timestamp = with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::execute_vote(1, result));
 			assert_noop!(Tellor::execute_vote(1, result), Error::VoteAlreadyExecuted); // vote already executed
 			assert_noop!(
@@ -280,12 +281,12 @@ fn execute_vote() {
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_reporter),
 				query_id,
-				Timestamp::get()
+				now()
 			));
-			Timestamp::get()
+			now()
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(2));
 			// start new round
 			assert_ok!(Tellor::begin_dispute(
@@ -295,16 +296,16 @@ fn execute_vote() {
 			));
 		});
 
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_noop!(Tellor::execute_vote(2, result), Error::VoteNotFinal); // vote must be the final vote
 		});
 
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(3));
 			assert_noop!(Tellor::execute_vote(3, result), Error::TallyDisputePeriodActive); // must wait longer
 		});
 
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::execute_vote(3, result));
 		});
 	});
@@ -341,21 +342,17 @@ fn tally_votes() {
 			));
 			assert_noop!(Tellor::tally_votes(1), Error::InvalidDispute); // Cannot tally a dispute that does not exist
 
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), 1, Some(false)));
 			assert_noop!(Tellor::tally_votes(1), Error::VotingPeriodActive); // Time for voting has not elapsed
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(1));
 			assert_noop!(Tellor::tally_votes(1), Error::VoteAlreadyTallied); // cannot re-tally a dispute
 
 			let vote_info = Tellor::get_vote_info(1).unwrap();
-			assert_eq!(vote_info.tally_date, Timestamp::get(), "Tally date should be correct");
+			assert_eq!(vote_info.tally_date, now(), "Tally date should be correct");
 		});
 	});
 }
@@ -390,11 +387,7 @@ fn vote() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter_2),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter_2), query_id, now()));
 			assert_noop!(
 				Tellor::vote(RuntimeOrigin::signed(reporter_2), 2, Some(false)),
 				Error::InvalidVote
@@ -408,7 +401,7 @@ fn vote() {
 			); // Sender has already voted
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(1));
 			assert_noop!(
 				Tellor::vote(RuntimeOrigin::signed(reporter_2), 1, Some(true)),
@@ -481,11 +474,7 @@ fn did_vote() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			assert!(!Tellor::did_vote(1, reporter), "voter's voted status should be correct");
 			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), 1, Some(true)));
 			assert!(Tellor::did_vote(1, reporter), "voter's voted status should be correct");
@@ -519,14 +508,10 @@ fn get_dispute_info() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			let dispute_info = Tellor::get_dispute_info(1).unwrap();
 			assert_eq!(dispute_info.0, query_id, "disputed query id should be correct");
-			assert_eq!(dispute_info.1, Timestamp::get(), "disputed timestamp should be correct");
+			assert_eq!(dispute_info.1, now(), "disputed timestamp should be correct");
 			assert_eq!(dispute_info.2, uint_value(100), "disputed value should be correct");
 			assert_eq!(dispute_info.3, reporter, "disputed reporter should be correct");
 		});
@@ -568,12 +553,12 @@ fn get_disputes_by_reporter() {
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_initiator),
 				query_id,
-				Timestamp::get()
+				now()
 			));
-			Timestamp::get()
+			now()
 		});
 
-		with_block_after(ReportingLock::get(), || {
+		with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -586,15 +571,15 @@ fn get_disputes_by_reporter() {
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_initiator),
 				query_id,
-				Timestamp::get()
+				now()
 			));
 			assert_eq!(Tellor::get_disputes_by_reporter(reporter), vec![2, 1]);
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(1));
 		});
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
 		});
 
@@ -629,7 +614,7 @@ fn get_open_disputes_on_id() {
 				0,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
 		with_block(|| {
 			assert_ok!(Tellor::report_stake_deposited(
@@ -649,18 +634,14 @@ fn get_open_disputes_on_id() {
 			assert_eq!(Tellor::get_open_disputes_on_id(query_id), 0);
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, timestamp));
 			assert_eq!(Tellor::get_open_disputes_on_id(query_id), 1);
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			assert_eq!(Tellor::get_open_disputes_on_id(query_id), 2);
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(1));
 		});
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
 		});
 
@@ -695,18 +676,14 @@ fn get_vote_count() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			assert_eq!(Tellor::get_vote_count(), 1, "vote count should increment correctly");
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(1));
 		});
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
 			assert_eq!(
 				Tellor::get_vote_count(),
@@ -720,11 +697,7 @@ fn get_vote_count() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			assert_eq!(Tellor::get_vote_count(), 2, "vote count should increment correctly");
 		})
 	});
@@ -756,20 +729,16 @@ fn get_vote_info() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), 1, Some(true)));
-			(Timestamp::get(), System::block_number())
+			(now(), System::block_number())
 		});
 
-		let tallied = with_block_after(VoteRoundPeriod::get(), || {
+		let tallied = with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(1));
-			Timestamp::get()
+			now()
 		});
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
 			let vote = Tellor::get_vote_info(1).unwrap();
 			let parachain_id: u32 = ParachainId::get();
@@ -833,23 +802,19 @@ fn get_vote_rounds() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			let parachain_id: u32 = ParachainId::get();
 			let identifier = keccak_256(&ethabi::encode(&vec![
 				Token::Uint(parachain_id.into()),
 				Token::FixedBytes(query_id.0.to_vec()),
-				Token::Uint(Timestamp::get().into()),
+				Token::Uint(now().into()),
 			]))
 			.into();
 			assert_eq!(Tellor::get_vote_rounds(identifier), vec![1]);
-			(Timestamp::get(), identifier)
+			(now(), identifier)
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(1));
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, timestamp));
 			assert_eq!(Tellor::get_vote_rounds(identifier), vec![1, 2]);
@@ -884,11 +849,7 @@ fn get_vote_tally_by_address() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 		});
 
 		with_block(|| {
@@ -905,11 +866,7 @@ fn get_vote_tally_by_address() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 
 			assert_eq!(
 				Tellor::get_vote_tally_by_address(reporter),
@@ -967,20 +924,16 @@ fn get_tips_by_address() {
 				query_data,
 			));
 
-			assert_ok!(Tellor::begin_dispute(
-				RuntimeOrigin::signed(reporter),
-				query_id,
-				Timestamp::get()
-			));
+			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 			assert_ok!(Tellor::vote(RuntimeOrigin::signed(user), 1, Some(true)));
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(1));
-			Timestamp::get()
+			now()
 		});
 
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::execute_vote(1, VoteResult::Passed));
 			assert_eq!(
 				Tellor::get_vote_info(1).unwrap().users,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,12 +1,16 @@
 use crate::{
 	contracts::registry,
+	mock,
 	mock::*,
 	types::{AccountIdOf, Address, Amount, AmountOf, DisputeIdOf, QueryDataOf, QueryIdOf, ValueOf},
 	xcm::{ethereum_xcm, XcmConfig},
 	Event, Origin, StakeAmount,
 };
 use ethabi::{Bytes, Token, Uint};
-use frame_support::{assert_noop, assert_ok, traits::PalletInfoAccess};
+use frame_support::{
+	assert_noop, assert_ok,
+	traits::{PalletInfoAccess, UnixTime},
+};
 use sp_core::{bytes::to_hex, keccak_256, H256};
 use sp_runtime::traits::BadOrigin;
 use xcm::{latest::prelude::*, DoubleEncoded};
@@ -18,6 +22,11 @@ mod oracle;
 type Config = crate::types::Configuration;
 type Configuration = crate::pallet::Configuration<Test>;
 type Error = crate::Error<Test>;
+
+// Returns the timestamp for the current block.
+fn now() -> crate::types::Timestamp {
+	<mock::Timestamp as UnixTime>::now().as_secs()
+}
 
 fn submit_value_and_begin_dispute(
 	reporter: AccountIdOf<Test>,
@@ -31,7 +40,7 @@ fn submit_value_and_begin_dispute(
 		0,
 		query_data
 	));
-	assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, Timestamp::get()));
+	assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now()));
 
 	match System::events().last().unwrap().event {
 		RuntimeEvent::Tellor(Event::<Test>::NewDispute { dispute_id, .. }) => dispute_id,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,7 +2,7 @@ use crate::{
 	contracts::registry,
 	mock,
 	mock::*,
-	types::{AccountIdOf, Address, Amount, AmountOf, DisputeIdOf, QueryDataOf, QueryIdOf, ValueOf},
+	types::{AccountIdOf, Address, Amount, AmountOf, DisputeIdOf, QueryDataOf, QueryId, ValueOf},
 	xcm::{ethereum_xcm, XcmConfig},
 	Event, Origin, StakeAmount,
 };
@@ -30,7 +30,7 @@ fn now() -> crate::types::Timestamp {
 
 fn submit_value_and_begin_dispute(
 	reporter: AccountIdOf<Test>,
-	query_id: QueryIdOf<Test>,
+	query_id: QueryId,
 	query_data: QueryDataOf<Test>,
 ) -> DisputeIdOf<Test> {
 	assert_ok!(Tellor::submit_value(

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -1,18 +1,18 @@
 use super::*;
 use crate::{
-	types::{Nonce, QueryIdOf, TimestampOf},
-	Config, DAY_IN_MILLISECONDS,
+	constants::{
+		DAY_IN_SECONDS, DISPUTE_PERIOD, REPORTING_LOCK, TALLIED_VOTE_DISPUTE_PERIOD,
+		WITHDRAWAL_PERIOD,
+	},
+	types::{Nonce, QueryIdOf, Timestamp},
+	Config,
 };
 use frame_support::{assert_noop, assert_ok};
-use sp_core::{bounded::BoundedBTreeMap, bounded_btree_map, bounded_vec, Get, U256};
+use sp_core::{bounded::BoundedBTreeMap, bounded_btree_map, bounded_vec, U256};
 use sp_runtime::traits::BadOrigin;
 
 type BoundedReportsSubmittedByQueryId =
 	BoundedBTreeMap<QueryIdOf<Test>, u128, <Test as Config>::MaxQueriesPerReporter>;
-type VoteRoundPeriod = <Test as Config>::VoteRoundPeriod;
-type ReportingLock = <Test as Config>::ReportingLock;
-type VoteTallyDisputePeriod = <Test as Config>::VoteTallyDisputePeriod;
-type WithdrawalPeriod = <Test as Config>::WithdrawalPeriod;
 
 #[test]
 fn deposit_stake() {
@@ -50,7 +50,7 @@ fn deposit_stake() {
 			assert_eq!(Tellor::get_total_stakers(), 1);
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.address, address);
-			assert_eq!(staker_details.start_date, Timestamp::get());
+			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.staked_balance, amount);
 			assert_eq!(staker_details.locked_balance, 0);
 			assert_eq!(staker_details.reward_debt, 0);
@@ -113,7 +113,7 @@ fn remove_value() {
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L127
 	ext.execute_with(|| {
 		with_block(|| {
-			let timestamp = Timestamp::get();
+			let timestamp = now();
 
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
@@ -191,7 +191,7 @@ fn request_stake_withdraw() {
 			));
 
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.start_date, Timestamp::get());
+			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.staked_balance, amount);
 			assert_eq!(staker_details.locked_balance, 0);
 			assert_eq!(staker_details.staked, true);
@@ -214,7 +214,7 @@ fn request_stake_withdraw() {
 				address
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.start_date, Timestamp::get());
+			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.reward_debt, 0);
 			assert_eq!(staker_details.staked_balance, token(990));
 			assert_eq!(staker_details.locked_balance, token(10));
@@ -239,7 +239,7 @@ fn request_stake_withdraw() {
 				address
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.start_date, Timestamp::get());
+			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.reward_debt, 0);
 			assert_eq!(staker_details.staked_balance, token(990));
 			assert_eq!(staker_details.locked_balance, token(10));
@@ -290,11 +290,11 @@ fn slash_reporter() {
 			submit_value_and_begin_dispute(reporter, query_id, query_data.clone()) // start dispute, required for slashing
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(dispute_id));
 		});
 
-		let dispute_id = with_block_after(VoteTallyDisputePeriod::get(), || {
+		let dispute_id = with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			// Slash when locked balance = 0
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.staked_balance, amount);
@@ -332,11 +332,11 @@ fn slash_reporter() {
 			submit_value_and_begin_dispute(reporter, query_id, query_data.clone()) // start dispute, required for slashing
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(dispute_id));
 		});
 
-		let dispute_id = with_block_after(VoteTallyDisputePeriod::get(), || {
+		let dispute_id = with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			// Slash when lockedBalance >= stakeAmount
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
@@ -367,11 +367,11 @@ fn slash_reporter() {
 			submit_value_and_begin_dispute(reporter, query_id, query_data.clone()) // start dispute, required for slashing
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(dispute_id));
 		});
 
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			// Slash when 0 < locked balance < stake amount
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
@@ -411,7 +411,7 @@ fn slash_reporter() {
 			assert_eq!(Tellor::get_total_stake_amount(), token(75));
 		});
 
-		let dispute_id = with_block_after(WithdrawalPeriod::get(), || {
+		let dispute_id = with_block_after(WITHDRAWAL_PERIOD, || {
 			assert_ok!(Tellor::report_stake_withdrawn(
 				Origin::Staking.into(),
 				reporter,
@@ -427,11 +427,11 @@ fn slash_reporter() {
 			submit_value_and_begin_dispute(reporter, query_id, query_data) // start dispute, required for slashing
 		});
 
-		with_block_after(VoteRoundPeriod::get(), || {
+		with_block_after(DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::tally_votes(dispute_id));
 		});
 
-		with_block_after(VoteTallyDisputePeriod::get(), || {
+		with_block_after(TALLIED_VOTE_DISPUTE_PERIOD, || {
 			assert_ok!(Tellor::report_slash(
 				Origin::Governance.into(),
 				dispute_id,
@@ -531,8 +531,8 @@ fn submit_value() {
 			);
 		});
 
-		with_block_after(WithdrawalPeriod::get(), || {
-			let timestamp = Timestamp::get();
+		with_block_after(WITHDRAWAL_PERIOD, || {
+			let timestamp = now();
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -575,8 +575,8 @@ fn submit_value() {
 				query_data.clone()
 			));
 		});
-		with_block_after(ReportingLock::get(), || {
-			let timestamp = Timestamp::get();
+		with_block_after(REPORTING_LOCK, || {
+			let timestamp = now();
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -666,7 +666,7 @@ fn withdraw_stake() {
 			assert_eq!(staker_details.locked_balance, token(10));
 		});
 
-		with_block_after(WithdrawalPeriod::get(), || {
+		with_block_after(WITHDRAWAL_PERIOD, || {
 			assert_ok!(Tellor::report_stake_withdrawn(
 				Origin::Staking.into(),
 				reporter,
@@ -717,7 +717,7 @@ fn get_block_number_by_timestamp() {
 				query_data.clone(),
 			));
 			assert_eq!(
-				Tellor::get_block_number_by_timestamp(query_id, Timestamp::get()).unwrap(),
+				Tellor::get_block_number_by_timestamp(query_id, now()).unwrap(),
 				System::block_number()
 			)
 		});
@@ -783,7 +783,7 @@ fn get_new_value_count_by_query_id() {
 			));
 		});
 
-		with_block_after(ReportingLock::get(), || {
+		with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -822,10 +822,10 @@ fn get_report_details() {
 				0,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
 
-		let timestamp_2 = with_block_after(ReportingLock::get(), || {
+		let timestamp_2 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -833,10 +833,10 @@ fn get_report_details() {
 				0,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
 
-		let timestamp_3 = with_block_after(ReportingLock::get(), || {
+		let timestamp_3 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -844,8 +844,8 @@ fn get_report_details() {
 				0,
 				query_data.clone(),
 			));
-			assert_ok!(Tellor::remove_value(query_id, Timestamp::get()));
-			Timestamp::get()
+			assert_ok!(Tellor::remove_value(query_id, now()));
+			now()
 		});
 
 		assert_eq!(Tellor::get_report_details(query_id, timestamp_1).unwrap(), (reporter, false));
@@ -858,7 +858,7 @@ fn get_report_details() {
 #[test]
 fn get_reporting_lock() {
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L398
-	let reporting_lock: TimestampOf<Test> = ReportingLock::get();
+	let reporting_lock: Timestamp = REPORTING_LOCK;
 	assert_eq!(Tellor::get_reporting_lock(), reporting_lock)
 }
 
@@ -888,10 +888,7 @@ fn get_reporter_by_timestamp() {
 				0,
 				query_data.clone(),
 			));
-			assert_eq!(
-				Tellor::get_reporter_by_timestamp(query_id, Timestamp::get()).unwrap(),
-				reporter
-			)
+			assert_eq!(Tellor::get_reporter_by_timestamp(query_id, now()).unwrap(), reporter)
 		});
 	});
 }
@@ -922,7 +919,7 @@ fn get_reporter_last_timestamp() {
 				0,
 				query_data.clone(),
 			));
-			assert_eq!(Tellor::get_reporter_last_timestamp(reporter).unwrap(), Timestamp::get())
+			assert_eq!(Tellor::get_reporter_last_timestamp(reporter).unwrap(), now())
 		});
 	});
 }
@@ -955,7 +952,7 @@ fn get_reports_submitted_by_address() {
 			));
 		});
 
-		with_block_after(ReportingLock::get(), || {
+		with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -996,7 +993,7 @@ fn get_reports_submitted_by_address_and_query_id() {
 			));
 		});
 
-		with_block_after(ReportingLock::get(), || {
+		with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1056,11 +1053,11 @@ fn get_staker_info() {
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.address, address);
-			assert_eq!(staker_details.start_date, Timestamp::get());
+			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.staked_balance, token(900));
 			assert_eq!(staker_details.locked_balance, token(100));
 			assert_eq!(staker_details.reward_debt, 0);
-			assert_eq!(staker_details.reporter_last_timestamp, Timestamp::get());
+			assert_eq!(staker_details.reporter_last_timestamp, now());
 			assert_eq!(staker_details.reports_submitted, 1);
 			assert_eq!(staker_details.start_vote_count, 0);
 			assert_eq!(staker_details.start_vote_tally, 0);
@@ -1098,7 +1095,7 @@ fn get_time_of_last_new_value() {
 				0,
 				query_data.clone(),
 			));
-			assert_eq!(Tellor::get_time_of_last_new_value().unwrap(), Timestamp::get())
+			assert_eq!(Tellor::get_time_of_last_new_value().unwrap(), now())
 		});
 	});
 }
@@ -1131,7 +1128,7 @@ fn get_timestamp_by_query_and_index() {
 			));
 		});
 
-		with_block_after(ReportingLock::get(), || {
+		with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1139,10 +1136,7 @@ fn get_timestamp_by_query_and_index() {
 				0,
 				query_data.clone(),
 			));
-			assert_eq!(
-				Tellor::get_timestamp_by_query_id_and_index(query_id, 1).unwrap(),
-				Timestamp::get()
-			)
+			assert_eq!(Tellor::get_timestamp_by_query_id_and_index(query_id, 1).unwrap(), now())
 		})
 	});
 }
@@ -1175,7 +1169,7 @@ fn get_timestamp_index_by_timestamp() {
 			));
 		});
 
-		with_block_after(ReportingLock::get(), || {
+		with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1183,10 +1177,7 @@ fn get_timestamp_index_by_timestamp() {
 				0,
 				query_data.clone(),
 			));
-			assert_eq!(
-				Tellor::get_timestamp_index_by_timestamp(query_id, Timestamp::get()).unwrap(),
-				1
-			)
+			assert_eq!(Tellor::get_timestamp_index_by_timestamp(query_id, now()).unwrap(), 1)
 		})
 	});
 }
@@ -1294,7 +1285,7 @@ fn is_in_dispute() {
 				query_data.clone(),
 			));
 
-			let timestamp = Timestamp::get();
+			let timestamp = now();
 			assert!(!Tellor::is_in_dispute(query_id, timestamp));
 			// Value can only be removed via dispute
 			assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, timestamp));
@@ -1331,7 +1322,7 @@ fn retrieve_data() {
 			));
 		});
 
-		with_block_after(ReportingLock::get(), || {
+		with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1339,14 +1330,11 @@ fn retrieve_data() {
 				0,
 				query_data.clone(),
 			));
-			assert_eq!(
-				Tellor::retrieve_data(query_id, Timestamp::get()).unwrap(),
-				uint_value(4001)
-			);
+			assert_eq!(Tellor::retrieve_data(query_id, now()).unwrap(), uint_value(4001));
 
 			// Test max/min values for _timestamp arg
 			assert_eq!(Tellor::retrieve_data(query_id, 0), None);
-			assert_eq!(Tellor::retrieve_data(query_id, <TimestampOf<Test>>::MAX), None);
+			assert_eq!(Tellor::retrieve_data(query_id, Timestamp::MAX), None);
 		})
 	});
 }
@@ -1391,9 +1379,9 @@ fn get_index_for_data_before() {
 				0,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
-		let timestamp_1 = with_block_after(ReportingLock::get(), || {
+		let timestamp_1 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1401,9 +1389,9 @@ fn get_index_for_data_before() {
 				1,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
-		let timestamp_2 = with_block_after(ReportingLock::get(), || {
+		let timestamp_2 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1411,20 +1399,20 @@ fn get_index_for_data_before() {
 				2,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
 
 		assert_eq!(Tellor::get_index_for_data_before(query_id, timestamp_2), Some(1));
 
 		// advance time and test
 		for year in 1..2 {
-			with_block_after(year * 365 * DAY_IN_MILLISECONDS, || {
+			with_block_after(year * 365 * DAY_IN_SECONDS, || {
 				assert_eq!(Tellor::get_index_for_data_before(query_id, timestamp_2), Some(1));
 			});
 		}
 
 		for i in 0..50 {
-			with_block_after(ReportingLock::get(), || {
+			with_block_after(REPORTING_LOCK, || {
 				assert_ok!(Tellor::submit_value(
 					RuntimeOrigin::signed(reporter),
 					query_id,
@@ -1434,7 +1422,7 @@ fn get_index_for_data_before() {
 				));
 			});
 		}
-		let timestamp_52 = Timestamp::get();
+		let timestamp_52 = now();
 
 		// test last value disputed
 		with_block(|| {
@@ -1459,7 +1447,7 @@ fn get_index_for_data_before() {
 		let query_data: QueryDataOf<Test> = spot_price("ksm", "usd").try_into().unwrap();
 		let query_id = keccak_256(query_data.as_ref()).into();
 
-		let timestamp_0 = with_block_after(ReportingLock::get(), || {
+		let timestamp_0 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1467,9 +1455,9 @@ fn get_index_for_data_before() {
 				0,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
-		let timestamp_1 = with_block_after(ReportingLock::get(), || {
+		let timestamp_1 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1479,14 +1467,14 @@ fn get_index_for_data_before() {
 			));
 
 			assert_ok!(Tellor::remove_value(query_id, timestamp_0));
-			assert_ok!(Tellor::remove_value(query_id, Timestamp::get()));
-			Timestamp::get()
+			assert_ok!(Tellor::remove_value(query_id, now()));
+			now()
 		});
 
 		assert_eq!(Tellor::get_index_for_data_before(query_id, timestamp_1 + 1), None);
 		assert_eq!(Tellor::get_index_for_data_before(query_id, timestamp_0 + 1), None);
 
-		let timestamp_2 = with_block_after(ReportingLock::get(), || {
+		let timestamp_2 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1494,10 +1482,10 @@ fn get_index_for_data_before() {
 				0,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
 
-		with_block_after(ReportingLock::get(), || {
+		with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1538,9 +1526,9 @@ fn get_data_before() {
 				0,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
-		let timestamp_2 = with_block_after(ReportingLock::get(), || {
+		let timestamp_2 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1548,9 +1536,9 @@ fn get_data_before() {
 				1,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
-		let timestamp_3 = with_block_after(ReportingLock::get(), || {
+		let timestamp_3 = with_block_after(REPORTING_LOCK, || {
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
 				query_id,
@@ -1558,7 +1546,7 @@ fn get_data_before() {
 				2,
 				query_data.clone(),
 			));
-			Timestamp::get()
+			now()
 		});
 
 		assert_eq!(
@@ -1572,7 +1560,7 @@ fn get_data_before() {
 
 		// advance time one year and test
 		for year in 1..2 {
-			with_block_after(year * 365 * DAY_IN_MILLISECONDS, || {
+			with_block_after(year * 365 * DAY_IN_SECONDS, || {
 				assert_eq!(
 					Tellor::get_data_before(query_id, timestamp_3 + 1),
 					Some((uint_value(170), timestamp_3))
@@ -1586,7 +1574,7 @@ fn get_data_before() {
 
 		// submit 50 values and test
 		for i in 0..50 {
-			with_block_after(ReportingLock::get(), || {
+			with_block_after(REPORTING_LOCK, || {
 				assert_ok!(Tellor::submit_value(
 					RuntimeOrigin::signed(reporter),
 					query_id,

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -4,7 +4,7 @@ use crate::{
 		DAY_IN_SECONDS, DISPUTE_PERIOD, REPORTING_LOCK, TALLIED_VOTE_DISPUTE_PERIOD,
 		WITHDRAWAL_PERIOD,
 	},
-	types::{Nonce, QueryIdOf, Timestamp},
+	types::{Nonce, QueryId, Timestamp},
 	Config,
 };
 use frame_support::{assert_noop, assert_ok};
@@ -12,7 +12,7 @@ use sp_core::{bounded::BoundedBTreeMap, bounded_btree_map, bounded_vec, U256};
 use sp_runtime::traits::BadOrigin;
 
 type BoundedReportsSubmittedByQueryId =
-	BoundedBTreeMap<QueryIdOf<Test>, u128, <Test as Config>::MaxQueriesPerReporter>;
+	BoundedBTreeMap<QueryId, u128, <Test as Config>::MaxQueriesPerReporter>;
 
 #[test]
 fn deposit_stake() {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,4 @@
+use crate::types::Timestamp;
 use sp_std::vec::Vec;
 use xcm::latest::prelude::*;
 
@@ -11,7 +12,7 @@ pub trait SendXcm {
 }
 
 /// This trait helps pallets read data from Tellor
-pub trait UsingTellor<AccountId, Price, QueryId, Timestamp> {
+pub trait UsingTellor<AccountId, Price, QueryId> {
 	/// Retrieves the next value for the query identifier after the specified timestamp.
 	/// # Arguments
 	/// * `query_id` - The query identifier to look up the value for.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::types::Timestamp;
+use crate::types::{QueryId, Timestamp};
 use sp_std::vec::Vec;
 use xcm::latest::prelude::*;
 
@@ -12,7 +12,7 @@ pub trait SendXcm {
 }
 
 /// This trait helps pallets read data from Tellor
-pub trait UsingTellor<AccountId, Price, QueryId> {
+pub trait UsingTellor<AccountId, Price> {
 	/// Retrieves the next value for the query identifier after the specified timestamp.
 	/// # Arguments
 	/// * `query_id` - The query identifier to look up the value for.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,8 @@
 use super::Config;
 use frame_support::pallet_prelude::*;
 pub(crate) use governance::Tally;
-use sp_core::{bounded::BoundedBTreeMap, H160, U256};
+use sp_core::{bounded::BoundedBTreeMap, H160, H256, U256};
+pub(crate) use sp_runtime::traits::Keccak256;
 
 pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 pub type Address = H160;
@@ -9,18 +10,15 @@ pub(crate) type Amount = U256;
 pub(crate) type AmountOf<T> = <T as Config>::Amount;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
 pub(crate) type DisputeIdOf<T> = <T as Config>::DisputeId;
-pub(crate) type DisputeOf<T> =
-	governance::Dispute<AccountIdOf<T>, QueryIdOf<T>, Timestamp, ValueOf<T>>;
-pub(crate) type FeedIdOf<T> = <T as Config>::Hash;
+pub(crate) type DisputeOf<T> = governance::Dispute<AccountIdOf<T>, QueryId, Timestamp, ValueOf<T>>;
+pub(crate) type FeedId = H256;
 pub(crate) type FeedOf<T> = autopay::Feed<AmountOf<T>, Timestamp, <T as Config>::MaxRewardClaims>;
 pub(crate) type FeedDetailsOf<T> = autopay::FeedDetails<AmountOf<T>, Timestamp>;
-pub(crate) type _HashOf<T> = <T as Config>::Hash;
-pub(crate) type HasherOf<T> = <T as Config>::Hasher;
 pub(crate) type Nonce = u128;
 pub(crate) type ParaId = u32;
 pub(crate) type PriceOf<T> = <T as Config>::Price;
 pub(crate) type QueryDataOf<T> = BoundedVec<u8, <T as Config>::MaxQueryDataLength>;
-pub(crate) type QueryIdOf<T> = <T as Config>::Hash;
+pub(crate) type QueryId = H256;
 pub(crate) type ReportOf<T> = oracle::Report<
 	AccountIdOf<T>,
 	BlockNumberOf<T>,
@@ -29,18 +27,18 @@ pub(crate) type ReportOf<T> = oracle::Report<
 	<T as Config>::MaxTimestamps,
 >;
 pub(crate) type StakeInfoOf<T> =
-	oracle::StakeInfo<AmountOf<T>, <T as Config>::MaxQueriesPerReporter, QueryIdOf<T>, Timestamp>;
+	oracle::StakeInfo<AmountOf<T>, <T as Config>::MaxQueriesPerReporter, QueryId, Timestamp>;
 pub(crate) type Timestamp = u64;
 pub(crate) type TipOf<T> = autopay::Tip<AmountOf<T>, Timestamp>;
 pub(crate) type ValueOf<T> = BoundedVec<u8, <T as Config>::MaxValueLength>;
 pub(crate) type VoteCountOf<T> = DisputeIdOf<T>;
-pub(crate) type VoteIdOf<T> = <T as Config>::Hash;
+pub(crate) type VoteId = H256;
 pub(crate) type VoteOf<T> = governance::Vote<
 	AccountIdOf<T>,
 	AmountOf<T>,
 	BlockNumberOf<T>,
 	Timestamp,
-	VoteIdOf<T>,
+	VoteId,
 	<T as Config>::MaxVotes,
 >;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use super::Config;
-use frame_support::{pallet_prelude::*, traits::Time};
+use frame_support::pallet_prelude::*;
 pub(crate) use governance::Tally;
 use sp_core::{bounded::BoundedBTreeMap, H160, U256};
 
@@ -10,15 +10,12 @@ pub(crate) type AmountOf<T> = <T as Config>::Amount;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
 pub(crate) type DisputeIdOf<T> = <T as Config>::DisputeId;
 pub(crate) type DisputeOf<T> =
-	governance::Dispute<AccountIdOf<T>, QueryIdOf<T>, TimestampOf<T>, ValueOf<T>>;
+	governance::Dispute<AccountIdOf<T>, QueryIdOf<T>, Timestamp, ValueOf<T>>;
 pub(crate) type FeedIdOf<T> = <T as Config>::Hash;
-pub(crate) type FeedOf<T> =
-	autopay::Feed<AmountOf<T>, TimestampOf<T>, <T as Config>::MaxRewardClaims>;
-pub(crate) type FeedDetailsOf<T> = autopay::FeedDetails<AmountOf<T>, TimestampOf<T>>;
+pub(crate) type FeedOf<T> = autopay::Feed<AmountOf<T>, Timestamp, <T as Config>::MaxRewardClaims>;
+pub(crate) type FeedDetailsOf<T> = autopay::FeedDetails<AmountOf<T>, Timestamp>;
 pub(crate) type _HashOf<T> = <T as Config>::Hash;
 pub(crate) type HasherOf<T> = <T as Config>::Hasher;
-#[cfg(test)]
-pub(crate) type MomentOf<T> = <<T as Config>::Time as Time>::Moment;
 pub(crate) type Nonce = u128;
 pub(crate) type ParaId = u32;
 pub(crate) type PriceOf<T> = <T as Config>::Price;
@@ -27,18 +24,14 @@ pub(crate) type QueryIdOf<T> = <T as Config>::Hash;
 pub(crate) type ReportOf<T> = oracle::Report<
 	AccountIdOf<T>,
 	BlockNumberOf<T>,
-	TimestampOf<T>,
+	Timestamp,
 	ValueOf<T>,
 	<T as Config>::MaxTimestamps,
 >;
-pub(crate) type StakeInfoOf<T> = oracle::StakeInfo<
-	AmountOf<T>,
-	<T as Config>::MaxQueriesPerReporter,
-	QueryIdOf<T>,
-	TimestampOf<T>,
->;
-pub(crate) type TimestampOf<T> = <<T as Config>::Time as Time>::Moment;
-pub(crate) type TipOf<T> = autopay::Tip<AmountOf<T>, TimestampOf<T>>;
+pub(crate) type StakeInfoOf<T> =
+	oracle::StakeInfo<AmountOf<T>, <T as Config>::MaxQueriesPerReporter, QueryIdOf<T>, Timestamp>;
+pub(crate) type Timestamp = u64;
+pub(crate) type TipOf<T> = autopay::Tip<AmountOf<T>, Timestamp>;
 pub(crate) type ValueOf<T> = BoundedVec<u8, <T as Config>::MaxValueLength>;
 pub(crate) type VoteCountOf<T> = DisputeIdOf<T>;
 pub(crate) type VoteIdOf<T> = <T as Config>::Hash;
@@ -46,7 +39,7 @@ pub(crate) type VoteOf<T> = governance::Vote<
 	AccountIdOf<T>,
 	AmountOf<T>,
 	BlockNumberOf<T>,
-	TimestampOf<T>,
+	Timestamp,
 	VoteIdOf<T>,
 	<T as Config>::MaxVotes,
 >;


### PR DESCRIPTION
- Replaces `Time` trait usage with `UnixTime` for more explicit timestamp values (`u64`)
- Uses seconds via `now()` function to align `timestamp` values with EVM smart contract timestamps
- Converts time period configuration items to constants
- Converts `Hasher` config item to use `keccak256` hashing algorithm exclusively via type alias