### PR TITLE
fix: require u128 for token amount

### DIFF
--- a/runtime-api/src/autopay.rs
+++ b/runtime-api/src/autopay.rs
@@ -16,18 +16,18 @@
 
 use codec::{Decode, Encode};
 use sp_std::vec::Vec;
-use tellor::FeedDetails;
+use tellor::{Amount, FeedDetails};
 
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
-pub struct FeedDetailsWithQueryData<Amount> {
+pub struct FeedDetailsWithQueryData {
 	/// Feed details for feed identifier with funding.
-	pub details: FeedDetails<Amount>,
+	pub details: FeedDetails,
 	/// Query data for requested data
 	pub query_data: Vec<u8>,
 }
 
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
-pub struct SingleTipWithQueryData<Amount> {
+pub struct SingleTipWithQueryData {
 	/// Query data with single tip for requested data.
 	pub query_data: Vec<u8>,
 	/// Reward amount for request.

--- a/runtime-api/src/governance.rs
+++ b/runtime-api/src/governance.rs
@@ -15,17 +15,18 @@
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
 use codec::{Decode, Encode};
+use tellor::{Amount, Timestamp};
 
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
-pub struct VoteInfo<Amount, BlockNumber, Timestamp> {
+pub struct VoteInfo<BlockNumber> {
 	pub vote_round: u8,
 	pub start_date: Timestamp,
 	pub block_number: BlockNumber,
 	pub fee: Amount,
 	pub tally_date: Timestamp,
-	pub users_does_support: Amount,
-	pub users_against: Amount,
-	pub users_invalid_query: Amount,
+	pub users_does_support: u128,
+	pub users_against: u128,
+	pub users_invalid_query: u128,
 	pub reporters_does_support: u128,
 	pub reporters_against: u128,
 	pub reporters_invalid_query: u128,

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -22,7 +22,7 @@ pub use autopay::{FeedDetailsWithQueryData, SingleTipWithQueryData};
 use codec::Codec;
 pub use governance::VoteInfo;
 use sp_std::vec::Vec;
-use tellor::{DisputeId, FeedDetails, FeedId, QueryId, Timestamp, Tip, VoteResult};
+use tellor::{Amount, DisputeId, FeedDetails, FeedId, QueryId, Timestamp, Tip, VoteResult};
 
 mod autopay;
 mod governance;
@@ -30,7 +30,7 @@ mod governance;
 mod tests;
 
 sp_api::decl_runtime_apis! {
-	pub trait TellorAutoPay<AccountId: Codec, Amount: Codec>
+	pub trait TellorAutoPay<AccountId: Codec>
 	{
 		/// Read current data feeds.
 		/// # Arguments
@@ -51,12 +51,12 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Unique feed identifier of parameters.
 		/// # Returns
 		/// Details of the specified feed.
-		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails<Amount>>;
+		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails>;
 
 		/// Read currently funded feed details.
 		/// # Returns
 		/// Details for funded feeds.
-		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData<Amount>>;
+		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData>;
 
 		/// Read currently funded feeds.
 		/// # Returns
@@ -71,7 +71,7 @@ sp_api::decl_runtime_apis! {
 		/// Read currently funded single tips with query data.
 		/// # Returns
 		/// The current single tips.
-		fn get_funded_single_tips_info() -> Vec<SingleTipWithQueryData<Amount>>;
+		fn get_funded_single_tips_info() -> Vec<SingleTipWithQueryData>;
 
 		/// Read the number of past tips for a query identifier.
 		/// # Arguments
@@ -85,7 +85,7 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Identifier of reported data.
 		/// # Returns
 		/// All past tips.
-		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Amount>>;
+		fn get_past_tips(query_id: QueryId) -> Vec<Tip>;
 
 		/// Read a past tip for a query identifier and index.
 		/// # Arguments
@@ -93,7 +93,7 @@ sp_api::decl_runtime_apis! {
 		/// * `index` - The index of the tip.
 		/// # Returns
 		/// The past tip, if found.
-		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Amount>>;
+		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip>;
 
 		/// Look up a query identifier from a data feed identifier.
 		/// # Arguments
@@ -137,7 +137,7 @@ sp_api::decl_runtime_apis! {
 		fn get_tips_by_address(user: AccountId) -> Amount;
 	}
 
-	pub trait TellorOracle<AccountId: Codec, Amount: Codec, BlockNumber: Codec, StakeInfo: Codec, Value: Codec> where
+	pub trait TellorOracle<AccountId: Codec, BlockNumber: Codec, StakeInfo: Codec, Value: Codec> where
 	{
 		/// Returns the block number at a given timestamp.
 		/// # Arguments
@@ -282,7 +282,7 @@ sp_api::decl_runtime_apis! {
 		fn retrieve_data(query_id: QueryId, timestamp: Timestamp) -> Option<Value>;
 	}
 
-	pub trait TellorGovernance<AccountId: Codec, Amount: Codec, BlockNumber: Codec, Value: Codec> where
+	pub trait TellorGovernance<AccountId: Codec, BlockNumber: Codec, Value: Codec> where
 	{
 		/// Determines if an account voted for a specific dispute round.
 		/// # Arguments
@@ -333,7 +333,7 @@ sp_api::decl_runtime_apis! {
 		/// # Returns
 		/// Information on a vote for a given dispute identifier including: the vote identifier, the
 		/// vote information, whether it has been executed, the vote result and the dispute initiator.
-		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<Amount,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)>;
+		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<BlockNumber>,bool,Option<VoteResult>,AccountId)>;
 
 		/// Returns the voting rounds for a given dispute identifier.
 		/// # Arguments

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::types::{Address, Amount, ParaId};
+use crate::types::{Address, ParaId};
 use sp_core::U256;
 use sp_std::{vec, vec::Vec};
 

--- a/src/contracts/registry.rs
+++ b/src/contracts/registry.rs
@@ -19,7 +19,7 @@ use super::*;
 pub(crate) fn register(
 	para_id: ParaId,
 	pallet_index: u8,
-	stake_amount: impl Into<Amount>,
+	stake_amount: impl Into<U256>,
 ) -> Vec<u8> {
 	const FUNCTION: [u8; 4] = [40, 162, 149, 29];
 	Call::new(&FUNCTION)

--- a/src/contracts/staking.rs
+++ b/src/contracts/staking.rs
@@ -18,7 +18,7 @@ use super::*;
 
 pub(crate) fn confirm_parachain_stake_withdraw_request(
 	address: impl Into<Address>,
-	amount: impl Into<Amount>,
+	amount: impl Into<U256>,
 ) -> Vec<u8> {
 	const FUNCTION: [u8; 4] = [116, 48, 87, 226];
 	Call::new(&FUNCTION).address(address.into()).uint(amount.into()).encode()

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -23,7 +23,7 @@ use frame_support::{
 };
 use frame_system as system;
 use once_cell::sync::Lazy;
-use sp_core::{ConstU32, H256};
+use sp_core::{ConstU128, ConstU32, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup},
@@ -36,14 +36,14 @@ use std::{
 use xcm::latest::prelude::*;
 
 pub(crate) type AccountId = u128; // u64 is not enough to hold bytes used to generate bounty account
-type Balance = u64;
+type Balance = u128;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 pub(crate) const EVM_PARA_ID: u32 = 2000;
 pub(crate) const PALLET_INDEX: u8 = 3;
 pub(crate) const PARA_ID: u32 = 3000;
-pub(crate) const UNIT: u64 = 1_000_000_000_000;
+pub(crate) const UNIT: u128 = 1_000_000_000_000_000_000;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
@@ -78,7 +78,7 @@ impl system::Config for Test {
 	type DbWeight = ();
 	type Version = ();
 	type PalletInfo = PalletInfo;
-	type AccountData = pallet_balances::AccountData<u64>;
+	type AccountData = pallet_balances::AccountData<u128>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
@@ -91,7 +91,7 @@ impl pallet_balances::Config for Test {
 	type Balance = Balance;
 	type DustRemoval = ();
 	type RuntimeEvent = RuntimeEvent;
-	type ExistentialDeposit = ConstU64<1>;
+	type ExistentialDeposit = ConstU128<1>;
 	type AccountStore = System;
 	type WeightInfo = ();
 	type MaxLocks = ();
@@ -121,7 +121,6 @@ parameter_types! {
 impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
-	type Amount = u64;
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -442,11 +442,7 @@ fn vote() {
 			); // Vote has already been tallied
 
 			let vote_info = Tellor::get_vote_info(dispute_id, 1).unwrap();
-			assert_eq!(
-				vote_info.users,
-				Tally::<AmountOf<Test>>::default(),
-				"users tally should be correct"
-			);
+			assert_eq!(vote_info.users, Tally::default(), "users tally should be correct");
 			assert_eq!(
 				vote_info.reporters.does_support, 0,
 				"reporters does_support tally should be correct"
@@ -823,14 +819,10 @@ fn get_vote_info() {
 			assert_eq!(vote.block_number, disputed_block, "vote block number should be correct");
 			assert_eq!(vote.fee, token(10), "vote fee should be correct");
 			assert_eq!(vote.tally_date, tallied, "vote tally date should be correct");
-			assert_eq!(
-				vote.users,
-				Tally::<AmountOf<Test>>::default(),
-				"vote users should be correct"
-			);
+			assert_eq!(vote.users, Tally::default(), "vote users should be correct");
 			assert_eq!(
 				vote.reporters,
-				Tally::<u128> { does_support: 1, against: 0, invalid_query: 0 },
+				Tally { does_support: 1, against: 0, invalid_query: 0 },
 				"vote reporters should be correct"
 			);
 			assert_eq!(vote.executed, true, "vote executed should be correct");
@@ -1003,7 +995,7 @@ fn get_tips_by_address() {
 			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
 			assert_eq!(
 				Tellor::get_vote_info(dispute_id, 1).unwrap().users,
-				Tally::<AmountOf<Test>> { does_support: token(20), against: 0, invalid_query: 0 },
+				Tally { does_support: token(20), against: 0, invalid_query: 0 },
 				"vote users does_support weight should be based on tip total"
 			)
 		});

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 	mock,
 	mock::*,
 	types::{
-		AccountIdOf, Address, Amount, AmountOf, DisputeId, QueryDataOf, QueryId, Timestamp, ValueOf,
+		AccountIdOf, Address, Amount, DisputeId, QueryDataOf, QueryId, Timestamp, ValueOf, U256,
 	},
 	xcm::{ethereum_xcm, XcmConfig},
 	Event, Origin, StakeAmount,
@@ -75,7 +75,7 @@ fn submit_value_and_begin_dispute(
 	}
 }
 
-fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<Amount>, address: Address) {
+fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<U256>, address: Address) {
 	assert_ok!(Tellor::report_stake_deposited(
 		Origin::Staking.into(),
 		reporter,
@@ -84,8 +84,8 @@ fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<Amount>, address
 	));
 }
 
-const STAKE_AMOUNT: AmountOf<Test> = 100 * UNIT;
-fn register_parachain(stake_amount: AmountOf<Test>) {
+const STAKE_AMOUNT: Amount = 100 * UNIT;
+fn register_parachain(stake_amount: Amount) {
 	let self_reserve = MultiLocation { parents: 0, interior: X1(PalletInstance(3)) };
 	assert_ok!(Tellor::register(
 		RuntimeOrigin::root(),
@@ -107,8 +107,8 @@ fn spot_price(asset: impl Into<String>, currency: impl Into<String>) -> Bytes {
 	])
 }
 
-fn token(amount: impl Into<f64>) -> AmountOf<Test> {
-	(amount.into() * UNIT as f64) as u64
+fn token(amount: impl Into<f64>) -> Amount {
+	(amount.into() * UNIT as f64) as u128
 }
 
 fn uint_value(value: impl Into<Uint>) -> ValueOf<Test> {
@@ -138,7 +138,7 @@ fn xcm_transact(
 
 #[test]
 fn converts_token() {
-	assert_eq!(token(2.97), 2_970_000_000_000)
+	assert_eq!(token(2.97), 2_970_000_000_000_000_000)
 }
 
 #[test]


### PR DESCRIPTION
Allowing uint types smaller than `u128` for token amounts can result in overflows when processing rewards, due to the TRB token using 18 decimals on Ethereum. This PR therefore standardises on `u128` for amounts, the largest built in Rust uint type, which aligns with [Polkadot](https://github.com/paritytech/polkadot/blob/26ff2cc11a6d9f7776c5ed7376f89c37fd214fbe/core-primitives/src/lib.rs#L100) and [Moonbeam](https://github.com/PureStake/moonbeam/blob/ebdeb40e4e185ebac02277adf5689d2d9d822b64/core-primitives/src/lib.rs#L36).