### PR TITLE
`execute_vote` improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1397,14 +1397,12 @@ pub mod pallet {
 
 		/// Reports a slashing of a reporter, due to a passing vote.
 		///
-		/// - `dispute_id`: The dispute identifier which resulted in the slashing.
 		/// - `reporter`: The address of the slashed reporter.
 		/// - `recipient`: The address of the recipient.
 		/// - `amount`: The slashed amount.
 		#[pallet::call_index(12)]
 		pub fn report_slash(
 			origin: OriginFor<T>,
-			dispute_id: DisputeId,
 			reporter: AccountIdOf<T>,
 			recipient: AccountIdOf<T>,
 			amount: Amount,
@@ -1415,9 +1413,6 @@ pub mod pallet {
 			let amount = amount
 				.saturated_into::<u128>() // todo: handle in single call skipping u128
 				.saturated_into::<AmountOf<T>>();
-
-			// execute vote, inferring result based on function called
-			Self::execute_vote(dispute_id, VoteResult::Passed)?;
 
 			<StakerDetails<T>>::try_mutate(&reporter, |maybe| -> DispatchResult {
 				match maybe {
@@ -1458,38 +1453,24 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Reports the result of a dispute as invalid.
+		/// Reports the result of a dispute.
 		///
 		/// - `dispute_id`: The identifier of the dispute.
+		/// - `result`: The result of the dispute.
 		#[pallet::call_index(13)]
-		pub fn report_invalid_dispute(
+		pub fn report_vote_executed(
 			origin: OriginFor<T>,
 			dispute_id: DisputeId,
+			result: VoteResult,
 		) -> DispatchResult {
 			// ensure origin is governance controller contract
 			T::GovernanceOrigin::ensure_origin(origin)?;
-			// execute vote, inferring result based on function called
-			Self::execute_vote(dispute_id, VoteResult::Invalid)?;
-			Ok(())
-		}
-
-		/// Slashes a dispute initiator, due to a failed vote.
-		///
-		/// - `dispute_id`: The identifier of the dispute.
-		#[pallet::call_index(14)]
-		pub fn slash_dispute_initiator(
-			origin: OriginFor<T>,
-			dispute_id: DisputeId,
-		) -> DispatchResult {
-			// ensure origin is governance controller contract
-			T::GovernanceOrigin::ensure_origin(origin)?;
-			// execute vote, inferring result based on function called
-			Self::execute_vote(dispute_id, VoteResult::Failed)?;
-			Ok(())
+			// execute vote
+			Self::execute_vote(dispute_id, result)
 		}
 
 		/// Deregisters the parachain from the Tellor controller contracts.
-		#[pallet::call_index(15)]
+		#[pallet::call_index(14)]
 		pub fn deregister(origin: OriginFor<T>) -> DispatchResult {
 			T::RegistrationOrigin::ensure_origin(origin)?;
 			ensure!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1063,10 +1063,14 @@ pub mod pallet {
 					.encode(),
 			);
 			// Push new vote round
-			let vote_round = <VoteRounds<T>>::mutate(dispute_id, |vote_rounds| {
-				vote_rounds.saturating_inc();
-				*vote_rounds
-			});
+			let vote_round = <VoteRounds<T>>::try_mutate(
+				dispute_id,
+				|vote_rounds| -> Result<u8, DispatchError> {
+					*vote_rounds =
+						vote_rounds.checked_add(1).ok_or(Error::<T>::MaxVoteRoundsReached)?;
+					Ok(*vote_rounds)
+				},
+			)?;
 
 			// Create new vote and dispute
 			let mut vote = VoteOf::<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,8 +461,6 @@ pub mod pallet {
 		VoteAlreadyExecuted,
 		/// Vote has already been tallied.
 		VoteAlreadyTallied,
-		/// Must be the final vote.
-		VoteNotFinal,
 		/// Vote must be tallied.
 		VoteNotTallied,
 		/// Time for voting has not elapsed.
@@ -1419,8 +1417,7 @@ pub mod pallet {
 				.saturated_into::<AmountOf<T>>();
 
 			// execute vote, inferring result based on function called
-			let vote_round = <VoteRounds<T>>::get(dispute_id); // use most recent round todo: check whether this should be a parameter
-			Self::execute_vote(dispute_id, vote_round, VoteResult::Passed)?;
+			Self::execute_vote(dispute_id, VoteResult::Passed)?;
 
 			<StakerDetails<T>>::try_mutate(&reporter, |maybe| -> DispatchResult {
 				match maybe {
@@ -1472,8 +1469,7 @@ pub mod pallet {
 			// ensure origin is governance controller contract
 			T::GovernanceOrigin::ensure_origin(origin)?;
 			// execute vote, inferring result based on function called
-			let vote_round = <VoteRounds<T>>::get(dispute_id); // use most recent round todo: check whether this should be a parameter
-			Self::execute_vote(dispute_id, vote_round, VoteResult::Invalid)?;
+			Self::execute_vote(dispute_id, VoteResult::Invalid)?;
 			Ok(())
 		}
 
@@ -1488,8 +1484,7 @@ pub mod pallet {
 			// ensure origin is governance controller contract
 			T::GovernanceOrigin::ensure_origin(origin)?;
 			// execute vote, inferring result based on function called
-			let vote_round = <VoteRounds<T>>::get(dispute_id); // use most recent round todo: check whether this should be a parameter
-			Self::execute_vote(dispute_id, vote_round, VoteResult::Failed)?;
+			Self::execute_vote(dispute_id, VoteResult::Failed)?;
 			Ok(())
 		}
 

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use crate::{constants::REPORTING_LOCK, mock::AccountId, types::Tally, Config, VoteResult};
-use frame_support::{assert_err, assert_noop, assert_ok, traits::Currency};
+use frame_support::{assert_noop, assert_ok, traits::Currency};
 use sp_core::{bounded::BoundedBTreeMap, bounded_btree_map};
 use sp_runtime::traits::BadOrigin;
 
@@ -293,7 +293,6 @@ fn begin_dispute_by_non_reporter() {
 		with_block_after(86_400 * 2, || {
 			assert_ok!(Tellor::report_slash(
 				Origin::Governance.into(),
-				dispute_id,
 				reporter,
 				another_reporter,
 				STAKE_AMOUNT.into()

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -417,8 +417,7 @@ fn execute_vote() {
 				STAKE_AMOUNT.into(),
 				Address::random()
 			));
-			//let balance_1 = Balances::balance(&dispute_reporter);
-			assert_noop!(Tellor::execute_vote(H256::random(), 1, result), Error::InvalidDispute);
+			assert_noop!(Tellor::execute_vote(H256::random(), result), Error::InvalidDispute);
 			// dispute id must be valid
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter_1),
@@ -438,16 +437,17 @@ fn execute_vote() {
 				pallet_balances::Error::<Test>::InsufficientBalance
 			); // must have tokens to pay for dispute
 			Balances::make_free_balance_be(&dispute_reporter, token(1_000));
+			let balance_1 = Balances::free_balance(&dispute_reporter);
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_reporter),
 				query_id,
 				timestamp_1,
 				None
 			));
-			//let balance_2 = Balances::balance(&dispute_reporter);
-			let dispute_1 = dispute_id(PARA_ID, query_id, timestamp_1);
+			let balance_2 = Balances::free_balance(&dispute_reporter);
+			let dispute_id = dispute_id(PARA_ID, query_id, timestamp_1);
 			assert_eq!(
-				Tellor::get_dispute_info(dispute_1).unwrap(),
+				Tellor::get_dispute_info(dispute_id).unwrap(),
 				(query_id, timestamp_1, uint_value(100), reporter_1)
 			);
 			assert_eq!(
@@ -456,37 +456,33 @@ fn execute_vote() {
 				"open disputes on id should be correct"
 			);
 			assert_eq!(
-				Tellor::get_vote_rounds(dispute_1),
+				Tellor::get_vote_rounds(dispute_id),
 				1,
 				"number of vote rounds should be correct"
 			);
-			// todo: assert_eq!(balance_1 - balance_2, token(10), "dispute fee paid should be correct");
+			assert_eq!(balance_1 - balance_2, token(10), "dispute fee paid should be correct");
 
-			assert_noop!(Tellor::execute_vote(H256::random(), 1, result), Error::InvalidDispute);
-			// dispute id must exist
-			assert_noop!(Tellor::execute_vote(dispute_1, 10, result), Error::InvalidVote); // vote round must exist
-			assert_noop!(Tellor::execute_vote(dispute_1, 1, result), Error::VoteNotTallied); // vote must be tallied
-			(timestamp_1, dispute_1)
+			assert_noop!(Tellor::execute_vote(H256::random(), result), Error::InvalidDispute); // dispute id must exist
+			assert_noop!(Tellor::execute_vote(dispute_id, result), Error::VoteNotTallied); // vote must be tallied
+			(timestamp_1, dispute_id)
 		});
 
 		// Tally votes after vote duration
 		with_block_after(86_400 * 2, || {
 			assert_ok!(Tellor::tally_votes(dispute_1, 1));
-			assert_noop!(
-				Tellor::execute_vote(dispute_1, 1, result),
-				Error::TallyDisputePeriodActive
-			); // a day must pass before execution
+			assert_noop!(Tellor::execute_vote(dispute_1, result), Error::TallyDisputePeriodActive);
+			// a day must pass before execution
 		});
 
 		// Execute after tally dispute period
 		let (timestamp_2, dispute_2) = with_block_after(86_400 * 2, || {
 			let previous_balance = Balances::free_balance(&dispute_reporter);
-			assert_ok!(Tellor::execute_vote(dispute_1, 1, result));
+			assert_ok!(Tellor::execute_vote(dispute_1, result));
 			let dispute_fee = Tellor::get_vote_info(dispute_1, 1).unwrap().fee;
 
 			assert_eq!(previous_balance + dispute_fee, Balances::free_balance(&dispute_reporter));
 
-			assert_noop!(Tellor::execute_vote(dispute_1, 1, result), Error::VoteAlreadyExecuted);
+			assert_noop!(Tellor::execute_vote(dispute_1, result), Error::VoteAlreadyExecuted);
 			// vote already executed
 			assert_noop!(
 				Tellor::begin_dispute(
@@ -527,35 +523,34 @@ fn execute_vote() {
 			(timestamp_2, dispute_id(PARA_ID, query_id, timestamp_2))
 		});
 
-		let dispute_3 = with_block_after(86_400 * 2, || {
+		with_block_after(86_400 * 2, || {
 			assert_ok!(Tellor::tally_votes(dispute_2, 1));
+			// Start another round
 			assert_ok!(Tellor::begin_dispute(
 				RuntimeOrigin::signed(dispute_reporter),
 				query_id,
 				timestamp_2,
 				None
 			));
-			dispute_id(PARA_ID, query_id, timestamp_2)
 		});
 
 		with_block_after(86_400 * 2, || {
-			assert_noop!(Tellor::execute_vote(dispute_2, 1, result), Error::VoteNotFinal);
-			// vote must be the final vote
+			assert_eq!(Tellor::get_vote_rounds(dispute_2), 2);
+			assert_noop!(Tellor::execute_vote(dispute_2, result), Error::VoteNotTallied);
+			// vote round must be tallied
 		});
 
 		with_block_after(86_400 * 2, || {
-			assert_ok!(Tellor::tally_votes(dispute_3, 2));
-			assert_noop!(
-				Tellor::execute_vote(dispute_3, 2, result),
-				Error::TallyDisputePeriodActive
-			); // must wait longer
+			assert_ok!(Tellor::tally_votes(dispute_2, 2));
+			assert_noop!(Tellor::execute_vote(dispute_2, result), Error::TallyDisputePeriodActive);
+			// must wait longer
 		});
 
 		with_block_after(86_400, || {
 			let previous_balance = Balances::free_balance(&dispute_reporter);
-			assert_ok!(Tellor::execute_vote(dispute_3, 2, result));
-			let first_round_fee = Tellor::get_vote_info(dispute_3, 1).unwrap().fee;
-			let second_round_fee = Tellor::get_vote_info(dispute_3, 2).unwrap().fee;
+			assert_ok!(Tellor::execute_vote(dispute_2, result));
+			let first_round_fee = Tellor::get_vote_info(dispute_2, 1).unwrap().fee;
+			let second_round_fee = Tellor::get_vote_info(dispute_2, 2).unwrap().fee;
 			assert_eq!(
 				previous_balance + first_round_fee + second_round_fee,
 				Balances::free_balance(&dispute_reporter)
@@ -885,7 +880,7 @@ fn get_disputes_by_reporter() {
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
 		});
 
 		assert_eq!(
@@ -964,7 +959,7 @@ fn get_open_disputes_on_id() {
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
 		});
 
 		assert_eq!(Tellor::get_open_disputes_on_id(query_id), 1);
@@ -1015,7 +1010,7 @@ fn get_vote_count() {
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
 			assert_eq!(
 				Tellor::get_vote_count(),
 				1,
@@ -1084,7 +1079,7 @@ fn get_vote_info() {
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
 			let vote = Tellor::get_vote_info(dispute_id, 1).unwrap();
 			let parachain_id: u32 = ParachainId::get();
 			assert_eq!(
@@ -1306,7 +1301,7 @@ fn get_tips_by_address() {
 
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, 1, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
 			assert_eq!(
 				Tellor::get_vote_info(dispute_id, 1).unwrap().users,
 				Tally::<AmountOf<Test>> { does_support: token(20), against: 0, invalid_query: 0 },

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -292,13 +292,7 @@ fn slash_reporter() {
 		let dispute_id = with_block(|| {
 			Balances::make_free_balance_be(&reporter, token(1_000));
 			assert_noop!(
-				Tellor::report_slash(
-					RuntimeOrigin::signed(reporter),
-					H256::zero(),
-					0,
-					0,
-					STAKE_AMOUNT.into()
-				),
+				Tellor::report_slash(RuntimeOrigin::signed(reporter), 0, 0, STAKE_AMOUNT.into()),
 				BadOrigin
 			);
 
@@ -325,18 +319,11 @@ fn slash_reporter() {
 			assert_eq!(staker_details.locked_balance, 0);
 			assert_eq!(Tellor::get_total_stake_amount(), amount);
 			assert_noop!(
-				Tellor::report_slash(
-					Origin::Governance.into(),
-					dispute_id,
-					0,
-					0,
-					(STAKE_AMOUNT + 1).into()
-				),
+				Tellor::report_slash(Origin::Governance.into(), 0, 0, (STAKE_AMOUNT + 1).into()),
 				Error::InsufficientStake
 			);
 			assert_ok!(Tellor::report_slash(
 				Origin::Governance.into(),
-				dispute_id,
 				reporter,
 				recipient,
 				STAKE_AMOUNT.into()
@@ -376,7 +363,6 @@ fn slash_reporter() {
 			assert!(staker_details.staked);
 			assert_ok!(Tellor::report_slash(
 				Origin::Governance.into(),
-				dispute_id,
 				reporter,
 				recipient,
 				STAKE_AMOUNT.into()
@@ -413,7 +399,6 @@ fn slash_reporter() {
 			assert_eq!(Tellor::get_total_stake_amount(), token(795));
 			assert_ok!(Tellor::report_slash(
 				Origin::Governance.into(),
-				dispute_id,
 				reporter,
 				recipient,
 				STAKE_AMOUNT.into()
@@ -464,7 +449,6 @@ fn slash_reporter() {
 		with_block_after(86_400, || {
 			assert_ok!(Tellor::report_slash(
 				Origin::Governance.into(),
-				dispute_id,
 				reporter,
 				recipient,
 				STAKE_AMOUNT.into()

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,7 +26,7 @@ pub(crate) type Amount = U256;
 pub(crate) type AmountOf<T> = <T as Config>::Amount;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
 pub type DisputeId = H256;
-pub(crate) type DisputeOf<T> = governance::Dispute<AccountIdOf<T>, ValueOf<T>>;
+pub(crate) type DisputeOf<T> = governance::Dispute<AccountIdOf<T>, AmountOf<T>, ValueOf<T>>;
 pub type FeedId = H256;
 pub(crate) type FeedOf<T> = autopay::Feed<AmountOf<T>, <T as Config>::MaxRewardClaims>;
 pub(crate) type FeedDetailsOf<T> = autopay::FeedDetails<AmountOf<T>>;
@@ -173,7 +173,7 @@ pub(crate) mod governance {
 	use super::*;
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-	pub struct Dispute<AccountId, Value> {
+	pub struct Dispute<AccountId, Amount, Value> {
 		/// Query identifier of disputed value
 		pub(crate) query_id: QueryId,
 		/// Timestamp of disputed value.
@@ -182,6 +182,8 @@ pub(crate) mod governance {
 		pub(crate) value: Value,
 		/// Reporter who submitted the disputed value.
 		pub(crate) disputed_reporter: AccountId,
+		/// Amount slashed from reporter.
+		pub(crate) slashed_amount: Amount,
 	}
 
 	#[derive(


### PR DESCRIPTION
- removes `vote_round` parameter from `execute_vote(..)`, as the final (current) round is always used once vote executed
- realigns implementation with `executeVote` implementation in source contract
- removes the `VoteNotFinal` error variant as no longer required. Previously a `dispute_id` was an integer and needed to be checked to ensure it was the final round. Now that it is a hash, we use the `VoteRound::get(dispute_id)` value to get the current (final) round.
- merges the `report_invalid_dispute` & `slash_dispute_initiator` functions into a single `report_vote_executed` dispatchable function
- removes `dispute_id` from `report_slash`, as this is called at time of first dispute rather than at time of vote execution. also removes call to `execute_vote` as handled later by contracts.
- adds missing `slashed_amount` on `Dispute`, as stake amount can change over time.

Closes #36 