### PR TITLE
Separate stake from balance

### DIFF
--- a/runtime-api/src/autopay.rs
+++ b/runtime-api/src/autopay.rs
@@ -19,17 +19,17 @@ use sp_std::vec::Vec;
 use tellor::FeedDetails;
 
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
-pub struct FeedDetailsWithQueryData<Amount> {
+pub struct FeedDetailsWithQueryData<Balance> {
 	/// Feed details for feed identifier with funding.
-	pub details: FeedDetails<Amount>,
+	pub details: FeedDetails<Balance>,
 	/// Query data for requested data
 	pub query_data: Vec<u8>,
 }
 
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
-pub struct SingleTipWithQueryData<Amount> {
+pub struct SingleTipWithQueryData<Balance> {
 	/// Query data with single tip for requested data.
 	pub query_data: Vec<u8>,
 	/// Reward amount for request.
-	pub tip: Amount,
+	pub tip: Balance,
 }

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -22,7 +22,7 @@ pub use autopay::{FeedDetailsWithQueryData, SingleTipWithQueryData};
 use codec::Codec;
 pub use governance::VoteInfo;
 use sp_std::vec::Vec;
-use tellor::{DisputeId, FeedDetails, FeedId, QueryId, Timestamp, Tip, VoteResult};
+use tellor::{Amount, DisputeId, FeedDetails, FeedId, QueryId, Timestamp, Tip, VoteResult};
 
 mod autopay;
 mod governance;
@@ -137,7 +137,7 @@ sp_api::decl_runtime_apis! {
 		fn get_tips_by_address(user: AccountId) -> Amount;
 	}
 
-	pub trait TellorOracle<AccountId: Codec, Amount: Codec, BlockNumber: Codec, StakeInfo: Codec, Value: Codec> where
+	pub trait TellorOracle<AccountId: Codec, BlockNumber: Codec, StakeInfo: Codec, Value: Codec> where
 	{
 		/// Returns the block number at a given timestamp.
 		/// # Arguments

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -43,10 +43,10 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 type AccountId = u64;
-type Amount = u64;
+type Balance = u64;
 type BlockNumber = u64;
 type MaxValueLength = ConstU32<4>;
-type StakeInfo = tellor::StakeInfo<Amount, <Test as tellor::Config>::MaxQueriesPerReporter>;
+type StakeInfo = tellor::StakeInfo<Balance, <Test as tellor::Config>::MaxQueriesPerReporter>;
 type Value = BoundedVec<u8, MaxValueLength>;
 
 // Configure a mock runtime to test implementation of the runtime-api
@@ -80,7 +80,7 @@ impl frame_system::Config for Test {
 	type DbWeight = ();
 	type Version = ();
 	type PalletInfo = PalletInfo;
-	type AccountData = pallet_balances::AccountData<u64>;
+	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
@@ -89,7 +89,7 @@ impl frame_system::Config for Test {
 	type MaxConsumers = ConstU32<16>;
 }
 impl pallet_balances::Config for Test {
-	type Balance = u64;
+	type Balance = Balance;
 	type DustRemoval = ();
 	type RuntimeEvent = RuntimeEvent;
 	type ExistentialDeposit = ConstU64<1>;
@@ -111,7 +111,7 @@ parameter_types! {
 impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
-	type Amount = Amount;
+	type Balance = Balance;
 	type Fee = ();
 	type Governance = ();
 	type GovernanceOrigin = EnsureGovernance;
@@ -153,20 +153,20 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 }
 
 mock_impl_runtime_apis! {
-	impl crate::TellorAutoPay<Block, AccountId, Amount> for Test {
+	impl crate::TellorAutoPay<Block, AccountId, Balance> for Test {
 		fn get_current_feeds(query_id: QueryId) -> Vec<FeedId>{
 			tellor::Pallet::<Test>::get_current_feeds(query_id)
 		}
 
-		fn get_current_tip(query_id: QueryId) -> Amount {
+		fn get_current_tip(query_id: QueryId) -> Balance {
 			tellor::Pallet::<Test>::get_current_tip(query_id)
 		}
 
-		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails<Amount>> {
+		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails<Balance>> {
 			tellor::Pallet::<Test>::get_data_feed(feed_id)
 		}
 
-		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData<Amount>> {
+		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData<Balance>> {
 			tellor::Pallet::<Test>::get_funded_feed_details().into_iter()
 			.map(|(details, query_data)| FeedDetailsWithQueryData {
 				details: details,
@@ -182,7 +182,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_funded_query_ids()
 		}
 
-		fn get_funded_single_tips_info() -> Vec<SingleTipWithQueryData<Amount>> {
+		fn get_funded_single_tips_info() -> Vec<SingleTipWithQueryData<Balance>> {
 			tellor::Pallet::<Test>::get_funded_single_tips_info().into_iter()
 			.map(|( query_data, tip)| SingleTipWithQueryData {
 				query_data: query_data.to_vec(),
@@ -195,11 +195,11 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_past_tip_count(query_id)
 		}
 
-		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Amount>> {
+		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Balance>> {
 			tellor::Pallet::<Test>::get_past_tips(query_id)
 		}
 
-		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Amount>>{
+		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Balance>>{
 			tellor::Pallet::<Test>::get_past_tip_by_index(query_id, index)
 		}
 
@@ -207,7 +207,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_query_id_from_feed_id(feed_id)
 		}
 
-		fn get_reward_amount(feed_id: FeedId, query_id: QueryId, timestamps: Vec<Timestamp>) -> Amount{
+		fn get_reward_amount(feed_id: FeedId, query_id: QueryId, timestamps: Vec<Timestamp>) -> Balance{
 			tellor::Pallet::<Test>::get_reward_amount(feed_id, query_id, timestamps)
 		}
 
@@ -219,12 +219,12 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_reward_claim_status_list(feed_id, query_id, timestamps)
 		}
 
-		fn get_tips_by_address(user: AccountId) -> Amount {
+		fn get_tips_by_address(user: AccountId) -> Balance {
 			tellor::Pallet::<Test>::get_tips_by_address(&user)
 		}
 	}
 
-	impl crate::TellorOracle<Block, AccountId, Amount, BlockNumber, StakeInfo, Value> for Test {
+	impl crate::TellorOracle<Block, AccountId, Balance, BlockNumber, StakeInfo, Value> for Test {
 		fn get_block_number_by_timestamp(query_id: QueryId, timestamp: Timestamp) -> Option<BlockNumber> {
 			tellor::Pallet::<Test>::get_block_number_by_timestamp(query_id, timestamp)
 		}
@@ -265,7 +265,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_reports_submitted_by_address_and_query_id(reporter, query_id)
 		}
 
-		fn get_stake_amount() -> Amount {
+		fn get_stake_amount() -> Balance {
 			tellor::Pallet::<Test>::get_stake_amount()
 		}
 
@@ -289,7 +289,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_timestamp_index_by_timestamp(query_id, timestamp)
 		}
 
-		fn get_total_stake_amount() -> Amount {
+		fn get_total_stake_amount() -> Balance {
 			tellor::Pallet::<Test>::get_total_stake_amount()
 		}
 
@@ -306,12 +306,12 @@ mock_impl_runtime_apis! {
 		}
 	}
 
-	impl crate::TellorGovernance<Block, AccountId, Amount, BlockNumber, Value> for Test {
+	impl crate::TellorGovernance<Block, AccountId, Balance, BlockNumber, Value> for Test {
 		fn did_vote(dispute_id: DisputeId, vote_round: u8, voter: AccountId) -> bool {
 			tellor::Pallet::<Test>::did_vote(dispute_id, vote_round, voter)
 		}
 
-		fn get_dispute_fee() -> Amount {
+		fn get_dispute_fee() -> Balance {
 			tellor::Pallet::<Test>::get_dispute_fee()
 		}
 
@@ -331,7 +331,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_vote_count()
 		}
 
-		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<Amount,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)> {
+		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<Balance,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)> {
 			tellor::Pallet::<Test>::get_vote_info(dispute_id, vote_round).map(|v| (
 			VoteInfo{
 					vote_round: v.vote_round,
@@ -494,10 +494,7 @@ mod autopay {
 	#[test]
 	fn get_tips_by_address() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(
-				Test.get_tips_by_address(&BLOCKID, AccountId::default()).unwrap(),
-				Amount::default()
-			);
+			assert_eq!(Test.get_tips_by_address(&BLOCKID, AccountId::default()).unwrap(), 0);
 		});
 	}
 }

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -30,12 +30,12 @@ use sp_core::{ConstU32, H256};
 use sp_runtime::{
 	generic::BlockId,
 	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
+	traits::{BlakeTwo256, IdentityLookup, Zero},
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 use tellor::{
-	DisputeId, EnsureGovernance, EnsureStaking, FeedDetails, FeedId, QueryId, Timestamp, Tip,
-	VoteResult,
+	Amount, DisputeId, EnsureGovernance, EnsureStaking, FeedDetails, FeedId, QueryId, Timestamp,
+	Tip, VoteResult,
 };
 use xcm::latest::prelude::*;
 
@@ -224,7 +224,7 @@ mock_impl_runtime_apis! {
 		}
 	}
 
-	impl crate::TellorOracle<Block, AccountId, Balance, BlockNumber, StakeInfo, Value> for Test {
+	impl crate::TellorOracle<Block, AccountId, BlockNumber, StakeInfo, Value> for Test {
 		fn get_block_number_by_timestamp(query_id: QueryId, timestamp: Timestamp) -> Option<BlockNumber> {
 			tellor::Pallet::<Test>::get_block_number_by_timestamp(query_id, timestamp)
 		}
@@ -265,7 +265,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_reports_submitted_by_address_and_query_id(reporter, query_id)
 		}
 
-		fn get_stake_amount() -> Balance {
+		fn get_stake_amount() -> Amount {
 			tellor::Pallet::<Test>::get_stake_amount()
 		}
 
@@ -289,7 +289,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_timestamp_index_by_timestamp(query_id, timestamp)
 		}
 
-		fn get_total_stake_amount() -> Balance {
+		fn get_total_stake_amount() -> Amount {
 			tellor::Pallet::<Test>::get_total_stake_amount()
 		}
 
@@ -598,7 +598,7 @@ mod oracle {
 	#[test]
 	fn get_stake_amount() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(Test.get_stake_amount(&BLOCKID).unwrap(), 0);
+			assert_eq!(Test.get_stake_amount(&BLOCKID).unwrap(), Amount::zero());
 		});
 	}
 
@@ -650,7 +650,7 @@ mod oracle {
 	#[test]
 	fn get_total_stake_amount() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(Test.get_total_stake_amount(&BLOCKID).unwrap(), 0);
+			assert_eq!(Test.get_total_stake_amount(&BLOCKID).unwrap(), Amount::zero());
 		});
 	}
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -19,7 +19,7 @@ use crate::constants::DISPUTE_SUB_ACCOUNT_ID;
 use sp_runtime::traits::Hash;
 
 impl<T: Config> Pallet<T> {
-	pub(super) fn add_staking_rewards(amount: AmountOf<T>) -> DispatchResult {
+	pub(super) fn add_staking_rewards(amount: BalanceOf<T>) -> DispatchResult {
 		let pallet_id = T::PalletId::get();
 		T::Token::transfer(
 			&pallet_id.into_account_truncating(),
@@ -116,13 +116,13 @@ impl<T: Config> Pallet<T> {
 		feed_funder: AccountIdOf<T>,
 		feed_id: FeedId,
 		query_id: QueryId,
-		amount: AmountOf<T>,
+		amount: BalanceOf<T>,
 	) -> DispatchResult {
 		let Some(mut feed) = <DataFeeds<T>>::get(query_id, feed_id) else {
 			return Err(Error::<T>::InvalidFeed.into());
 		};
 
-		ensure!(amount > <AmountOf<T>>::default(), Error::<T>::InvalidAmount);
+		ensure!(amount > Zero::zero(), Error::<T>::InvalidAmount);
 		feed.details.balance.saturating_accrue(amount);
 		T::Token::transfer(
 			&feed_funder,
@@ -131,9 +131,7 @@ impl<T: Config> Pallet<T> {
 			true,
 		)?;
 		// Add to array of feeds with funding
-		if feed.details.feeds_with_funding_index == 0 &&
-			feed.details.balance > <AmountOf<T>>::default()
-		{
+		if feed.details.feeds_with_funding_index == 0 && feed.details.balance > Zero::zero() {
 			let index = <FeedsWithFunding<T>>::try_mutate(
 				|feeds_with_funding| -> Result<usize, DispatchError> {
 					feeds_with_funding.try_push(feed_id).map_err(|_| Error::<T>::MaxFeedsFunded)?;
@@ -183,19 +181,19 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of reported data.
 	/// # Returns
 	/// Amount of tip.
-	pub fn get_current_tip(query_id: QueryId) -> AmountOf<T> {
+	pub fn get_current_tip(query_id: QueryId) -> BalanceOf<T> {
 		// todo: optimise
 		// if no tips, return 0
 		if <Tips<T>>::get(query_id).map_or(0, |t| t.len()) == 0 {
-			return AmountOf::<T>::default()
+			return Zero::zero()
 		}
 		let timestamp_retrieved = Self::_get_current_value(query_id).map_or(0, |v| v.1);
 		match <Tips<T>>::get(query_id) {
 			Some(tips) => match tips.last() {
 				Some(last_tip) if timestamp_retrieved < last_tip.timestamp => last_tip.amount,
-				_ => AmountOf::<T>::default(),
+				_ => Zero::zero(),
 			},
-			_ => AmountOf::<T>::default(),
+			_ => Zero::zero(),
 		}
 	}
 
@@ -266,7 +264,7 @@ impl<T: Config> Pallet<T> {
 	/// Get the latest dispute fee.
 	/// # Returns
 	/// The latest dispute fee.
-	pub fn get_dispute_fee() -> AmountOf<T> {
+	pub fn get_dispute_fee() -> BalanceOf<T> {
 		// todo: make configurable and use safe math
 		<StakeAmount<T>>::get().unwrap_or_default() / 10u8.into()
 	}
@@ -327,7 +325,7 @@ impl<T: Config> Pallet<T> {
 	/// Read currently funded single tips with query data.
 	/// # Returns
 	/// The current single tips.
-	pub fn get_funded_single_tips_info() -> Vec<(QueryDataOf<T>, AmountOf<T>)> {
+	pub fn get_funded_single_tips_info() -> Vec<(QueryDataOf<T>, BalanceOf<T>)> {
 		Self::get_funded_query_ids()
 			.into_iter()
 			.filter_map(|query_id| {
@@ -438,7 +436,7 @@ impl<T: Config> Pallet<T> {
 		query_id: QueryId,
 		timestamp: Timestamp,
 		claimer: &AccountIdOf<T>,
-	) -> Result<AmountOf<T>, Error<T>> {
+	) -> Result<BalanceOf<T>, Error<T>> {
 		ensure!(
 			Self::now().saturating_sub(timestamp) > 12 * HOURS,
 			Error::<T>::ClaimBufferNotPassed
@@ -470,14 +468,11 @@ impl<T: Config> Pallet<T> {
 					let min_tip = &mut tips.get_mut(min).ok_or(Error::<T>::InvalidIndex)?;
 					ensure!(timestamp_before < min_tip.timestamp, Error::<T>::TipAlreadyEarned);
 					ensure!(timestamp >= min_tip.timestamp, Error::<T>::TimestampIneligibleForTip);
-					ensure!(
-						min_tip.amount > <AmountOf<T>>::default(),
-						Error::<T>::TipAlreadyClaimed
-					);
+					ensure!(min_tip.amount > Zero::zero(), Error::<T>::TipAlreadyClaimed);
 
 					// todo: add test to ensure storage updated accordingly
 					let mut tip_amount = min_tip.amount;
-					min_tip.amount = <AmountOf<T>>::default();
+					min_tip.amount = Zero::zero();
 					let min_backup = min;
 
 					// check whether eligible for previous tips in array due to disputes
@@ -556,7 +551,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of reported data.
 	/// # Returns
 	/// All past tips.
-	pub fn get_past_tips(query_id: QueryId) -> Vec<Tip<AmountOf<T>>> {
+	pub fn get_past_tips(query_id: QueryId) -> Vec<Tip<BalanceOf<T>>> {
 		<Tips<T>>::get(query_id).map_or_else(Vec::default, |t| t.to_vec())
 	}
 
@@ -566,7 +561,7 @@ impl<T: Config> Pallet<T> {
 	/// * `index` - The index of the tip.
 	/// # Returns
 	/// The past tip, if found.
-	pub fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<AmountOf<T>>> {
+	pub fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<BalanceOf<T>>> {
 		<Tips<T>>::get(query_id).and_then(|t| t.get(index as usize).cloned())
 	}
 
@@ -660,7 +655,7 @@ impl<T: Config> Pallet<T> {
 		feed_id: FeedId,
 		query_id: QueryId,
 		timestamp: Timestamp,
-	) -> Result<AmountOf<T>, Error<T>> {
+	) -> Result<BalanceOf<T>, Error<T>> {
 		ensure!(Self::now().saturating_sub(timestamp) < 4 * WEEKS, Error::<T>::ClaimPeriodExpired);
 
 		let feed = <DataFeeds<T>>::get(query_id, feed_id).ok_or(Error::<T>::InvalidFeed)?;
@@ -678,7 +673,7 @@ impl<T: Config> Pallet<T> {
 			let v1 =
 				Self::bytes_to_price(value_retrieved.expect("value retrieved checked above; qed"))?;
 			let v2 = Self::bytes_to_price(value_retrieved_before)?;
-			if v2 == T::Price::default() {
+			if v2 == Zero::zero() {
 				price_change = 10_000;
 			} else if v1 >= v2 {
 				price_change = (T::Price::from(10_000u16).saturating_mul(v1.saturating_sub(v2)))
@@ -722,11 +717,11 @@ impl<T: Config> Pallet<T> {
 		feed_id: FeedId,
 		query_id: QueryId,
 		timestamps: Vec<Timestamp>,
-	) -> AmountOf<T> {
+	) -> BalanceOf<T> {
 		// todo: use boundedvec for timestamps
 
-		let Some(feed) = <DataFeeds<T>>::get(query_id, feed_id) else { return <AmountOf<T>>::default()};
-		let mut cumulative_reward = <AmountOf<T>>::default();
+		let Some(feed) = <DataFeeds<T>>::get(query_id, feed_id) else { return Zero::zero()};
+		let mut cumulative_reward = <BalanceOf<T>>::zero();
 		for timestamp in timestamps {
 			cumulative_reward.saturating_accrue(
 				Self::_get_reward_amount(feed_id, query_id, timestamp).unwrap_or_default(),
@@ -781,7 +776,7 @@ impl<T: Config> Pallet<T> {
 	/// Returns the amount required to report oracle values.
 	/// # Returns
 	/// The stake amount.
-	pub fn get_stake_amount() -> AmountOf<T> {
+	pub fn get_stake_amount() -> BalanceOf<T> {
 		<StakeAmount<T>>::get().unwrap_or_default()
 	}
 
@@ -833,14 +828,14 @@ impl<T: Config> Pallet<T> {
 	/// * `user` - Address of user to query.
 	/// # Returns
 	/// Total amount of tips paid by a user.
-	pub fn get_tips_by_address(user: &AccountIdOf<T>) -> AmountOf<T> {
+	pub fn get_tips_by_address(user: &AccountIdOf<T>) -> BalanceOf<T> {
 		<UserTipsTotal<T>>::get(user)
 	}
 
 	/// Returns the total amount staked for reporting.
 	/// # Returns
 	/// The total amount of token staked.
-	pub fn get_total_stake_amount() -> AmountOf<T> {
+	pub fn get_total_stake_amount() -> BalanceOf<T> {
 		<TotalStakeAmount<T>>::get()
 	}
 
@@ -857,7 +852,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	/// Count of the number of values received for the query identifier.
 	pub fn get_new_value_count_by_query_id(query_id: QueryId) -> usize {
-		<Reports<T>>::get(query_id).map_or(usize::default(), |r| r.timestamps.len())
+		<Reports<T>>::get(query_id).map_or(usize::zero(), |r| r.timestamps.len())
 	}
 
 	/// Returns the total number of votes
@@ -1003,11 +998,11 @@ impl<T: Config> Pallet<T> {
 
 	pub(super) fn update_stake_and_pay_rewards(
 		staker: &mut StakeInfoOf<T>,
-		new_staked_balance: AmountOf<T>,
+		new_staked_balance: BalanceOf<T>,
 	) -> Result<(), Error<T>> {
 		// todo: complete implementation
 		// _updateRewards();
-		if staker.staked_balance > <AmountOf<T>>::default() {
+		if staker.staked_balance > Zero::zero() {
 			// todo
 			// if address already has a staked balance, calculate and transfer pending rewards
 			// 	uint256 _pendingReward = (_staker.stakedBalance *

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use frame_support::{
 pub use pallet::*;
 use sp_core::Get;
 use sp_runtime::{
-	traits::{AccountIdConversion, CheckedDiv, Convert},
+	traits::{AccountIdConversion, CheckedDiv, Convert, Zero},
 	SaturatedConversion, Saturating,
 };
 use sp_std::vec::Vec;
@@ -70,9 +70,10 @@ pub mod pallet {
 	use ::xcm::latest::prelude::*;
 	use frame_support::{
 		pallet_prelude::*,
-		sp_runtime::traits::{AtLeast32BitUnsigned, Hash, MaybeSerializeDeserialize, Member},
+		sp_runtime::traits::{AtLeast32BitUnsigned, Hash},
 		traits::{
 			fungible::{Inspect, Transfer},
+			tokens::Balance,
 			PalletInfoAccess,
 		},
 		PalletId,
@@ -96,17 +97,8 @@ pub mod pallet {
 		type RuntimeOrigin: From<<Self as frame_system::Config>::RuntimeOrigin>
 			+ Into<result::Result<Origin, <Self as Config>::RuntimeOrigin>>;
 
-		/// The units in which we record amounts.
-		type Amount: Member
-			+ Parameter
-			+ AtLeast32BitUnsigned
-			+ Default
-			+ Copy
-			+ MaybeSerializeDeserialize
-			+ MaxEncodedLen
-			+ TypeInfo
-			+ Into<U256>
-			+ From<u64>;
+		/// The units in which we record balances.
+		type Balance: Balance + From<u64> + Into<U256>;
 
 		/// Percentage, 1000 is 100%, 50 is 5%, etc
 		#[pallet::constant]
@@ -186,7 +178,7 @@ pub mod pallet {
 		/// The on-chain time provider.
 		type Time: UnixTime;
 
-		type Token: Inspect<Self::AccountId, Balance = Self::Amount> + Transfer<Self::AccountId>;
+		type Token: Inspect<Self::AccountId, Balance = Self::Balance> + Transfer<Self::AccountId>;
 
 		/// Conversion from submitted value (bytes) to a price for price threshold evaluation.
 		type ValueConverter: Convert<Vec<u8>, Option<Self::Price>>;
@@ -226,14 +218,14 @@ pub mod pallet {
 	>;
 	#[pallet::storage]
 	pub(super) type UserTipsTotal<T> =
-		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, AmountOf<T>, ValueQuery>;
+		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, BalanceOf<T>, ValueQuery>;
 	// Oracle
 	#[pallet::storage]
 	pub(super) type Reports<T> = StorageMap<_, Blake2_128Concat, QueryId, ReportOf<T>>;
 	#[pallet::storage]
-	pub(super) type RewardRate<T> = StorageValue<_, AmountOf<T>>;
+	pub(super) type RewardRate<T> = StorageValue<_, BalanceOf<T>>;
 	#[pallet::storage]
-	pub(super) type StakeAmount<T> = StorageValue<_, AmountOf<T>>;
+	pub(super) type StakeAmount<T> = StorageValue<_, BalanceOf<T>>;
 	#[pallet::storage]
 	pub(super) type StakerDetails<T> =
 		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, StakeInfoOf<T>>;
@@ -243,7 +235,7 @@ pub mod pallet {
 	#[pallet::getter(fn time_of_last_new_value)]
 	pub(super) type TimeOfLastNewValue<T> = StorageValue<_, Timestamp>;
 	#[pallet::storage]
-	pub(super) type TotalStakeAmount<T> = StorageValue<_, AmountOf<T>, ValueQuery>;
+	pub(super) type TotalStakeAmount<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 	#[pallet::storage]
 	pub(super) type TotalStakers<T> = StorageValue<_, u128, ValueQuery>;
 	// Governance
@@ -279,7 +271,7 @@ pub mod pallet {
 		DataFeedFunded {
 			query_id: QueryId,
 			feed_id: FeedId,
-			amount: AmountOf<T>,
+			amount: BalanceOf<T>,
 			feed_funder: AccountIdOf<T>,
 			feed_details: FeedDetailsOf<T>,
 		},
@@ -291,11 +283,11 @@ pub mod pallet {
 			feed_creator: AccountIdOf<T>,
 		},
 		/// Emitted when a onetime tip is claimed.
-		OneTimeTipClaimed { query_id: QueryId, amount: AmountOf<T>, reporter: AccountIdOf<T> },
+		OneTimeTipClaimed { query_id: QueryId, amount: BalanceOf<T>, reporter: AccountIdOf<T> },
 		/// Emitted when a tip is added.
 		TipAdded {
 			query_id: QueryId,
-			amount: AmountOf<T>,
+			amount: BalanceOf<T>,
 			query_data: QueryDataOf<T>,
 			tipper: AccountIdOf<T>,
 		},
@@ -303,7 +295,7 @@ pub mod pallet {
 		TipClaimed {
 			feed_id: FeedId,
 			query_id: QueryId,
-			amount: AmountOf<T>,
+			amount: BalanceOf<T>,
 			reporter: AccountIdOf<T>,
 		},
 
@@ -318,15 +310,15 @@ pub mod pallet {
 			reporter: AccountIdOf<T>,
 		},
 		/// Emitted when a new staker is reported.
-		NewStakerReported { staker: AccountIdOf<T>, amount: AmountOf<T>, address: Address },
+		NewStakerReported { staker: AccountIdOf<T>, amount: BalanceOf<T>, address: Address },
 		/// Emitted when a stake slash is reported.
-		SlashReported { reporter: AccountIdOf<T>, recipient: AccountIdOf<T>, amount: AmountOf<T> },
+		SlashReported { reporter: AccountIdOf<T>, recipient: AccountIdOf<T>, amount: BalanceOf<T> },
 		/// Emitted when a stake withdrawal is reported.
 		StakeWithdrawnReported { staker: AccountIdOf<T> },
 		/// Emitted when a stake withdrawal request is reported.
 		StakeWithdrawRequestReported {
 			reporter: AccountIdOf<T>,
-			amount: AmountOf<T>,
+			amount: BalanceOf<T>,
 			address: Address,
 		},
 		/// Emitted when a value is removed (via governance).
@@ -353,7 +345,7 @@ pub mod pallet {
 
 		// Registration
 		/// Emitted when the pallet is (re-)configured.
-		Configured { stake_amount: AmountOf<T> },
+		Configured { stake_amount: BalanceOf<T> },
 		/// Emitted when registration with the controller contracts is attempted.
 		RegistrationAttempted { para_id: u32, contract_address: Address },
 		/// Emitted when deregistration from the controller contracts is attempted.
@@ -506,7 +498,7 @@ pub mod pallet {
 		#[pallet::call_index(0)]
 		pub fn register(
 			origin: OriginFor<T>,
-			stake_amount: AmountOf<T>,
+			stake_amount: BalanceOf<T>,
 			fees: Box<MultiAsset>,
 			weight_limit: WeightLimit,
 			require_weight_at_most: u64,
@@ -566,7 +558,7 @@ pub mod pallet {
 				Error::<T>::NoTipsSubmitted
 			);
 
-			let mut cumulative_reward = AmountOf::<T>::default();
+			let mut cumulative_reward = BalanceOf::<T>::zero();
 			for timestamp in timestamps {
 				cumulative_reward.saturating_accrue(Self::get_onetime_tip_amount(
 					query_id, timestamp, &reporter,
@@ -583,7 +575,7 @@ pub mod pallet {
 				false,
 			)?;
 			Self::add_staking_rewards(fee)?;
-			if Self::get_current_tip(query_id) == <AmountOf<T>>::default() {
+			if Self::get_current_tip(query_id) == Zero::zero() {
 				let index = <QueryIdsWithFundingIndex<T>>::get(query_id).unwrap_or_default();
 				if index != 0 {
 					// todo: safe math
@@ -636,9 +628,9 @@ pub mod pallet {
 
 			let mut feed = <DataFeeds<T>>::get(query_id, feed_id).ok_or(Error::<T>::InvalidFeed)?;
 			let balance = feed.details.balance;
-			ensure!(balance > AmountOf::<T>::default(), Error::<T>::InsufficientFeedBalance);
+			ensure!(balance > Zero::zero(), Error::<T>::InsufficientFeedBalance);
 
-			let mut cumulative_reward = AmountOf::<T>::default();
+			let mut cumulative_reward = BalanceOf::<T>::zero();
 			for timestamp in &timestamps {
 				ensure!(
 					Self::now().saturating_sub(*timestamp) > 12 * HOURS,
@@ -730,7 +722,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			feed_id: FeedId,
 			query_id: QueryId,
-			amount: AmountOf<T>,
+			amount: BalanceOf<T>,
 		) -> DispatchResult {
 			let feed_funder = ensure_signed(origin)?;
 			Self::_fund_feed(feed_funder, feed_id, query_id, amount)
@@ -751,14 +743,14 @@ pub mod pallet {
 		pub fn setup_data_feed(
 			origin: OriginFor<T>,
 			query_id: QueryId,
-			reward: AmountOf<T>,
+			reward: BalanceOf<T>,
 			start_time: Timestamp,
 			interval: Timestamp,
 			window: Timestamp,
 			price_threshold: u16,
-			reward_increase_per_second: AmountOf<T>,
+			reward_increase_per_second: BalanceOf<T>,
 			query_data: QueryDataOf<T>,
-			amount: AmountOf<T>,
+			amount: BalanceOf<T>,
 		) -> DispatchResult {
 			let feed_creator = ensure_signed(origin)?;
 			ensure!(query_id == Keccak256::hash(query_data.as_ref()), Error::<T>::InvalidQueryId);
@@ -775,13 +767,13 @@ pub mod pallet {
 			);
 			let feed = <DataFeeds<T>>::get(query_id, feed_id);
 			ensure!(feed.is_none(), Error::<T>::FeedAlreadyExists);
-			ensure!(reward > <AmountOf<T>>::default(), Error::<T>::InvalidReward);
+			ensure!(reward > Zero::zero(), Error::<T>::InvalidReward);
 			ensure!(interval > 0, Error::<T>::InvalidInterval);
 			ensure!(window < interval, Error::<T>::InvalidWindow);
 
 			let feed = FeedDetailsOf::<T> {
 				reward,
-				balance: <AmountOf<T>>::default(),
+				balance: Zero::zero(),
 				start_time,
 				interval,
 				window,
@@ -816,7 +808,7 @@ pub mod pallet {
 				query_data,
 				feed_creator: feed_creator.clone(),
 			});
-			if amount > <AmountOf<T>>::default() {
+			if amount > Zero::zero() {
 				Self::_fund_feed(feed_creator, feed_id, query_id, amount)?;
 			}
 			Ok(())
@@ -831,12 +823,12 @@ pub mod pallet {
 		pub fn tip(
 			origin: OriginFor<T>,
 			query_id: QueryId,
-			amount: AmountOf<T>,
+			amount: BalanceOf<T>,
 			query_data: QueryDataOf<T>,
 		) -> DispatchResult {
 			let tipper = ensure_signed(origin)?;
 			ensure!(query_id == Keccak256::hash(query_data.as_ref()), Error::<T>::InvalidQueryId);
-			ensure!(amount > AmountOf::<T>::default(), Error::<T>::InvalidAmount);
+			ensure!(amount > Zero::zero(), Error::<T>::InvalidAmount);
 
 			<Tips<T>>::try_mutate(query_id, |mut maybe_tips| -> DispatchResult {
 				match &mut maybe_tips {
@@ -862,9 +854,8 @@ pub mod pallet {
 								last_tip.cumulative_tips.saturating_accrue(amount);
 							},
 							_ => {
-								let cumulative_tips = tips
-									.last()
-									.map_or(<AmountOf<T>>::default(), |t| t.cumulative_tips);
+								let cumulative_tips =
+									tips.last().map_or(Zero::zero(), |t| t.cumulative_tips);
 								tips.try_push(Tip {
 									amount,
 									timestamp: Self::now().saturating_add(1u8.into()),
@@ -879,7 +870,7 @@ pub mod pallet {
 			})?;
 
 			if <QueryIdsWithFundingIndex<T>>::get(query_id).unwrap_or_default() == 0 &&
-				Self::get_current_tip(query_id) > <AmountOf<T>>::default()
+				Self::get_current_tip(query_id) > Zero::zero()
 			{
 				let len = <QueryIdsWithFunding<T>>::try_mutate(
 					|query_ids| -> Result<u32, DispatchError> {
@@ -924,10 +915,9 @@ pub mod pallet {
 			let report = <Reports<T>>::get(query_id);
 			ensure!(
 				nonce ==
-					report.as_ref().map_or(Nonce::default(), |r| r
-						.timestamps
-						.len()
-						.saturated_into::<Nonce>()) ||
+					report
+						.as_ref()
+						.map_or(Nonce::zero(), |r| r.timestamps.len().saturated_into::<Nonce>()) ||
 					nonce == 0, // todo: query || nonce == 0 check
 				Error::<T>::InvalidNonce
 			);
@@ -1109,7 +1099,7 @@ pub mod pallet {
 				});
 				// calculate dispute fee based on number of open disputes on query id
 				vote.fee = vote.fee.saturating_mul(
-					<AmountOf<T>>::from(2u8).saturating_pow(
+					<BalanceOf<T>>::from(2u8).saturating_pow(
 						<OpenDisputesOnId<T>>::get(query_id)
 							.ok_or(Error::<T>::InvalidIndex)?
 							.saturating_sub(1)
@@ -1129,7 +1119,7 @@ pub mod pallet {
 					Error::<T>::DisputeRoundReportingPeriodExpired
 				);
 				vote.fee = vote.fee.saturating_mul(
-					<AmountOf<T>>::from(2u8)
+					<BalanceOf<T>>::from(2u8)
 						.saturating_pow(vote_round.saturating_sub(1).saturated_into()),
 				);
 				dispute.value =
@@ -1260,15 +1250,13 @@ pub mod pallet {
 			// ensure origin is staking controller contract
 			T::StakingOrigin::ensure_origin(origin)?;
 
-			let amount = amount
-				.saturated_into::<u128>() // todo: handle in single call skipping u128
-				.saturated_into::<AmountOf<T>>();
+			let amount = U256ToBalance::<T>::convert(amount);
 			<StakerDetails<T>>::try_mutate(&reporter, |maybe| -> DispatchResult {
 				let mut staker = maybe.take().unwrap_or_else(|| <StakeInfoOf<T>>::new(address));
 				ensure!(address == staker.address, Error::<T>::InvalidAddress);
 				let staked_balance = staker.staked_balance;
 				let locked_balance = staker.locked_balance;
-				if locked_balance > <AmountOf<T>>::default() {
+				if locked_balance > Zero::zero() {
 					if locked_balance >= amount {
 						// if staker's locked balance covers full amount, use that
 						staker.locked_balance.saturating_reduce(amount);
@@ -1276,10 +1264,10 @@ pub mod pallet {
 					} else {
 						// otherwise, stake the whole locked balance
 						// 		toWithdraw -= _staker.lockedBalance; <- todo: check whether this is required
-						staker.locked_balance = <AmountOf<T>>::default();
+						staker.locked_balance = Zero::zero();
 					}
 				} else {
-					if staked_balance == <AmountOf<T>>::default() {
+					if staked_balance == Zero::zero() {
 						// todo:
 						// 		// if staked balance and locked balance equal 0, save current vote tally.
 						// 		// voting participation used for calculating rewards
@@ -1321,9 +1309,7 @@ pub mod pallet {
 			// ensure origin is staking controller contract
 			T::StakingOrigin::ensure_origin(origin)?;
 
-			let amount = amount
-				.saturated_into::<u128>() // todo: handle in single call skipping u128
-				.saturated_into::<AmountOf<T>>();
+			let amount = U256ToBalance::<T>::convert(amount);
 			<StakerDetails<T>>::try_mutate(&reporter, |maybe| -> DispatchResult {
 				match maybe {
 					None => Err(Error::<T>::InsufficientStake.into()),
@@ -1377,17 +1363,14 @@ pub mod pallet {
 			// ensure origin is staking controller contract
 			T::StakingOrigin::ensure_origin(origin)?;
 
-			let amount = amount
-				.saturated_into::<u128>() // todo: handle in single call skipping u128
-				.saturated_into::<AmountOf<T>>();
-
+			let amount = U256ToBalance::<T>::convert(amount);
 			<StakerDetails<T>>::try_mutate(&reporter, |maybe| -> DispatchResult {
 				match maybe {
 					None => Err(Error::<T>::InsufficientStake.into()),
 					Some(staker) => {
 						// Ensure reporter is locked and that enough time has passed
 						ensure!(
-							staker.locked_balance > <AmountOf<T>>::default(),
+							staker.locked_balance > Zero::zero(),
 							Error::<T>::NoWithdrawalRequested
 						);
 						ensure!(
@@ -1419,9 +1402,7 @@ pub mod pallet {
 			// ensure origin is governance controller contract
 			T::GovernanceOrigin::ensure_origin(origin)?;
 
-			let amount = amount
-				.saturated_into::<u128>() // todo: handle in single call skipping u128
-				.saturated_into::<AmountOf<T>>();
+			let amount = U256ToBalance::<T>::convert(amount);
 
 			<StakerDetails<T>>::try_mutate(&reporter, |maybe| -> DispatchResult {
 				match maybe {
@@ -1430,8 +1411,7 @@ pub mod pallet {
 						let staked_balance = staker.staked_balance;
 						let locked_balance = staker.locked_balance;
 						ensure!(
-							staked_balance.saturating_add(locked_balance) >
-								<AmountOf<T>>::default(),
+							staked_balance.saturating_add(locked_balance) > Zero::zero(),
 							Error::<T>::InsufficientStake
 						);
 						if locked_balance >= amount {
@@ -1447,12 +1427,12 @@ pub mod pallet {
 									.saturating_sub(amount.saturating_sub(locked_balance)),
 							)?;
 							// 	toWithdraw -= _lockedBalance; // todo: required?
-							staker.locked_balance = <AmountOf<T>>::default();
+							staker.locked_balance = Zero::zero();
 						} else {
 							// if sum(locked balance + staked balance) is less than stakeAmount, slash sum
 							// 	toWithdraw -= _lockedBalance; // todo: required?
-							Self::update_stake_and_pay_rewards(staker, <AmountOf<T>>::default())?;
-							staker.locked_balance = <AmountOf<T>>::default();
+							Self::update_stake_and_pay_rewards(staker, Zero::zero())?;
+							staker.locked_balance = Zero::zero();
 						}
 						Ok(())
 					},
@@ -1482,14 +1462,11 @@ pub mod pallet {
 		#[pallet::call_index(14)]
 		pub fn deregister(origin: OriginFor<T>) -> DispatchResult {
 			T::RegistrationOrigin::ensure_origin(origin)?;
-			ensure!(
-				Self::get_total_stake_amount() == <AmountOf<T>>::default(),
-				Error::<T>::ActiveStake
-			);
+			ensure!(Self::get_total_stake_amount() == Zero::zero(), Error::<T>::ActiveStake);
 
 			// Update local configuration
 			<StakeAmount<T>>::set(None);
-			Self::deposit_event(Event::Configured { stake_amount: <AmountOf<T>>::default() });
+			Self::deposit_event(Event::Configured { stake_amount: Zero::zero() });
 
 			// Register relevant supplied config with parachain registry contract
 			let config = <Configuration<T>>::take().ok_or(Error::<T>::NotRegistered)?;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -43,7 +43,6 @@ type Block = frame_system::mocking::MockBlock<Test>;
 pub(crate) const EVM_PARA_ID: u32 = 2000;
 pub(crate) const PALLET_INDEX: u8 = 3;
 pub(crate) const PARA_ID: u32 = 3000;
-pub(crate) const UNIT: u64 = 1_000_000_000_000;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -121,7 +121,7 @@ parameter_types! {
 impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
-	type Amount = u64;
+	type Balance = Balance;
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;

--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -2403,14 +2403,14 @@ fn get_current_feeds() {
 fn create_feed(
 	feed_creator: AccountIdOf<Test>,
 	query_id: QueryId,
-	reward: AmountOf<Test>,
+	reward: BalanceOf<Test>,
 	start_time: Timestamp,
 	interval: Timestamp,
 	window: Timestamp,
 	price_threshold: u16,
-	reward_increase_per_second: AmountOf<Test>,
+	reward_increase_per_second: BalanceOf<Test>,
 	query_data: QueryDataOf<Test>,
-	amount: AmountOf<Test>,
+	amount: BalanceOf<Test>,
 ) -> FeedId {
 	assert_ok!(Tellor::setup_data_feed(
 		RuntimeOrigin::signed(feed_creator),

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -712,7 +712,7 @@ fn vote() {
 			let vote_info = Tellor::get_vote_info(dispute_id, 1).unwrap();
 			assert_eq!(
 				vote_info.users,
-				Tally::<AmountOf<Test>>::default(),
+				Tally::<BalanceOf<Test>>::default(),
 				"users tally should be correct"
 			);
 			assert_eq!(
@@ -1136,7 +1136,7 @@ fn get_vote_info() {
 			assert_eq!(vote.tally_date, tallied, "vote tally date should be correct");
 			assert_eq!(
 				vote.users,
-				Tally::<AmountOf<Test>>::default(),
+				Tally::<BalanceOf<Test>>::default(),
 				"vote users should be correct"
 			);
 			assert_eq!(
@@ -1341,7 +1341,7 @@ fn get_tips_by_address() {
 			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
 			assert_eq!(
 				Tellor::get_vote_info(dispute_id, 1).unwrap().users,
-				Tally::<AmountOf<Test>> { does_support: token(20), against: 0, invalid_query: 0 },
+				Tally::<BalanceOf<Test>> { does_support: token(20), against: 0, invalid_query: 0 },
 				"vote users does_support weight should be based on tip total"
 			)
 		});

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -115,7 +115,7 @@ fn begin_dispute() {
 			assert!(
 				balance_before_begin_dispute -
 					balance_after_begin_dispute -
-					StakeAmount::<Test>::get().unwrap() / 10 ==
+					Tellor::convert(StakeAmount::<Test>::get().unwrap()) / 10 ==
 					0,
 				"dispute fee paid should be correct"
 			);
@@ -272,7 +272,7 @@ fn begin_dispute_by_non_reporter() {
 			assert!(
 				balance_before_begin_dispute -
 					balance_after_begin_dispute -
-					StakeAmount::<Test>::get().unwrap() / 10 ==
+					Tellor::convert(StakeAmount::<Test>::get().unwrap()) / 10 ==
 					0,
 				"dispute fee paid should be correct"
 			);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -32,6 +32,7 @@ use frame_support::{
 };
 use sp_core::{bytes::to_hex, keccak_256, H256};
 use sp_runtime::traits::BadOrigin;
+use std::convert::Into;
 use xcm::{latest::prelude::*, DoubleEncoded};
 
 mod autopay;
@@ -41,6 +42,14 @@ mod oracle;
 type Config = crate::types::Configuration;
 type Configuration = crate::pallet::Configuration<Test>;
 type Error = crate::Error<Test>;
+
+const STAKE_AMOUNT: u128 = 100_000_000_000_000_000_000;
+
+fn trb(amount: impl Into<f64>) -> Amount {
+	// TRB amount has 18 decimals
+	const UNIT: u128 = 1_000_000_000_000_000_000;
+	Amount::from((amount.into() * UNIT as f64) as u128)
+}
 
 fn dispute_id(para_id: u32, query_id: QueryId, timestamp: Timestamp) -> DisputeId {
 	keccak_256(&ethabi::encode(&[
@@ -85,12 +94,11 @@ fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<Amount>, address
 	));
 }
 
-const STAKE_AMOUNT: BalanceOf<Test> = 100 * UNIT;
-fn register_parachain(stake_amount: BalanceOf<Test>) {
+fn register_parachain(stake_amount: impl Into<Amount>) {
 	let self_reserve = MultiLocation { parents: 0, interior: X1(PalletInstance(3)) };
 	assert_ok!(Tellor::register(
 		RuntimeOrigin::root(),
-		stake_amount,
+		stake_amount.into(),
 		Box::new(MultiAsset { id: Concrete(self_reserve), fun: Fungible(300_000_000_000_000u128) }),
 		WeightLimit::Unlimited,
 		1000,
@@ -109,6 +117,8 @@ fn spot_price(asset: impl Into<String>, currency: impl Into<String>) -> Bytes {
 }
 
 fn token(amount: impl Into<f64>) -> BalanceOf<Test> {
+	// test parachain token has 12 decimals
+	pub(crate) const UNIT: u64 = 1_000_000_000_000;
 	(amount.into() * UNIT as f64) as u64
 }
 
@@ -166,18 +176,21 @@ fn register() {
 			for origin in
 				vec![RuntimeOrigin::signed(0), Origin::Governance.into(), Origin::Staking.into()]
 			{
-				assert_noop!(Tellor::register(origin, 0, fees.clone(), Unlimited, 0, 0), BadOrigin);
+				assert_noop!(
+					Tellor::register(origin, trb(0), fees.clone(), Unlimited, 0, 0),
+					BadOrigin
+				);
 			}
 
 			assert_ok!(Tellor::register(
 				RuntimeOrigin::root(),
-				STAKE_AMOUNT,
+				STAKE_AMOUNT.into(),
 				fees.clone(),
 				weight_limit.clone(),
 				require_weight_at_most,
 				gas_limit
 			));
-			assert_eq!(StakeAmount::<Test>::get().unwrap(), STAKE_AMOUNT);
+			assert_eq!(StakeAmount::<Test>::get().unwrap(), STAKE_AMOUNT.into());
 			assert_eq!(
 				Configuration::get().unwrap(),
 				Config {
@@ -189,7 +202,9 @@ fn register() {
 					gas_limit
 				}
 			);
-			System::assert_has_event(Event::Configured { stake_amount: STAKE_AMOUNT }.into());
+			System::assert_has_event(
+				Event::Configured { stake_amount: STAKE_AMOUNT.into() }.into(),
+			);
 
 			assert_eq!(
 				sent_xcm(),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,7 +19,8 @@ use crate::{
 	mock,
 	mock::*,
 	types::{
-		AccountIdOf, Address, Amount, AmountOf, DisputeId, QueryDataOf, QueryId, Timestamp, ValueOf,
+		AccountIdOf, Address, Amount, BalanceOf, DisputeId, QueryDataOf, QueryId, Timestamp,
+		ValueOf,
 	},
 	xcm::{ethereum_xcm, XcmConfig},
 	Event, Origin, StakeAmount,
@@ -84,8 +85,8 @@ fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<Amount>, address
 	));
 }
 
-const STAKE_AMOUNT: AmountOf<Test> = 100 * UNIT;
-fn register_parachain(stake_amount: AmountOf<Test>) {
+const STAKE_AMOUNT: BalanceOf<Test> = 100 * UNIT;
+fn register_parachain(stake_amount: BalanceOf<Test>) {
 	let self_reserve = MultiLocation { parents: 0, interior: X1(PalletInstance(3)) };
 	assert_ok!(Tellor::register(
 		RuntimeOrigin::root(),
@@ -107,7 +108,7 @@ fn spot_price(asset: impl Into<String>, currency: impl Into<String>) -> Bytes {
 	])
 }
 
-fn token(amount: impl Into<f64>) -> AmountOf<Test> {
+fn token(amount: impl Into<f64>) -> BalanceOf<Test> {
 	(amount.into() * UNIT as f64) as u64
 }
 

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -31,7 +31,7 @@ type BoundedReportsSubmittedByQueryId =
 fn deposit_stake() {
 	let reporter = 1;
 	let address = Address::random();
-	let amount = token(100);
+	let amount = trb(100);
 	let another_reporter = 2;
 	let mut ext = new_test_ext();
 
@@ -45,7 +45,7 @@ fn deposit_stake() {
 				Tellor::report_stake_deposited(
 					RuntimeOrigin::signed(another_reporter),
 					reporter,
-					amount.into(),
+					amount,
 					address
 				),
 				BadOrigin
@@ -53,7 +53,7 @@ fn deposit_stake() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				amount.into(),
+				amount,
 				address
 			));
 			System::assert_last_event(
@@ -65,7 +65,7 @@ fn deposit_stake() {
 			assert_eq!(staker_details.address, address);
 			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.staked_balance, amount);
-			assert_eq!(staker_details.locked_balance, 0);
+			assert_eq!(staker_details.locked_balance, trb(0));
 			assert_eq!(staker_details.reward_debt, 0);
 			assert_eq!(staker_details.reporter_last_timestamp, 0);
 			assert_eq!(staker_details.reports_submitted, 0);
@@ -80,7 +80,7 @@ fn deposit_stake() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				another_reporter,
-				0.into(),
+				trb(0),
 				Address::random()
 			));
 			assert_eq!(Tellor::get_total_stakers(), 1);
@@ -88,20 +88,20 @@ fn deposit_stake() {
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(5).into(),
+				trb(5),
 				address
 			));
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				token(10).into(),
+				trb(10),
 				address
 			));
 			assert_eq!(Tellor::get_total_stakers(), 1); // Ensure only unique addresses add to total stakers
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(105));
-			assert_eq!(staker_details.locked_balance, token(0));
-			assert_eq!(Tellor::get_total_stake_amount(), token(105));
+			assert_eq!(staker_details.staked_balance, trb(105));
+			assert_eq!(staker_details.locked_balance, trb(0));
+			assert_eq!(Tellor::get_total_stake_amount(), trb(105));
 		})
 	});
 }
@@ -170,7 +170,7 @@ fn remove_value() {
 #[test]
 fn request_stake_withdraw() {
 	let reporter = 1;
-	let amount = token(1_000);
+	let amount = trb(1_000);
 	let address = Address::random();
 	let mut ext = new_test_ext();
 
@@ -184,7 +184,7 @@ fn request_stake_withdraw() {
 				Tellor::report_staking_withdraw_request(
 					RuntimeOrigin::signed(reporter),
 					reporter,
-					token(10).into(),
+					trb(10),
 					address
 				),
 				BadOrigin
@@ -193,7 +193,7 @@ fn request_stake_withdraw() {
 				Tellor::report_staking_withdraw_request(
 					Origin::Staking.into(),
 					reporter,
-					token(5).into(),
+					trb(5),
 					address
 				),
 				Error::InsufficientStake
@@ -201,14 +201,14 @@ fn request_stake_withdraw() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				amount.into(),
+				amount,
 				address
 			));
 
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.staked_balance, amount);
-			assert_eq!(staker_details.locked_balance, 0);
+			assert_eq!(staker_details.locked_balance, trb(0));
 			assert_eq!(staker_details.staked, true);
 			assert_eq!(Tellor::get_total_stake_amount(), amount);
 			// expect(await tellor.totalRewardDebt()).to.equal(0) // todo:
@@ -225,16 +225,16 @@ fn request_stake_withdraw() {
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(10).into(),
+				trb(10),
 				address
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.reward_debt, 0);
-			assert_eq!(staker_details.staked_balance, token(990));
-			assert_eq!(staker_details.locked_balance, token(10));
+			assert_eq!(staker_details.staked_balance, trb(990));
+			assert_eq!(staker_details.locked_balance, trb(10));
 			assert_eq!(staker_details.staked, true);
-			assert_eq!(Tellor::get_total_stake_amount(), token(990));
+			assert_eq!(Tellor::get_total_stake_amount(), trb(990));
 			// expect(await tellor.totalRewardDebt()).to.equal(0) // todo:
 
 			// Test max/min for amount arg
@@ -256,17 +256,17 @@ fn request_stake_withdraw() {
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.reward_debt, 0);
-			assert_eq!(staker_details.staked_balance, token(990));
-			assert_eq!(staker_details.locked_balance, token(10));
+			assert_eq!(staker_details.staked_balance, trb(990));
+			assert_eq!(staker_details.locked_balance, trb(10));
 			assert_eq!(staker_details.staked, true);
-			assert_eq!(Tellor::get_total_stake_amount(), token(990));
+			assert_eq!(Tellor::get_total_stake_amount(), trb(990));
 			// expect(await tellor.totalRewardDebt()).to.equal(0) // todo:
 
 			assert_eq!(Tellor::get_total_stakers(), 1);
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(990).into(),
+				trb(990),
 				address
 			));
 			assert_eq!(Tellor::get_total_stakers(), 0);
@@ -280,7 +280,7 @@ fn slash_reporter() {
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let reporter = 1;
 	let recipient = 2;
-	let amount = token(1_000);
+	let amount = trb(1_000);
 	let address = Address::random();
 	let mut ext = new_test_ext();
 
@@ -299,7 +299,7 @@ fn slash_reporter() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				amount.into(),
+				amount,
 				address
 			));
 
@@ -316,7 +316,7 @@ fn slash_reporter() {
 			// Slash when locked balance = 0
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.staked_balance, amount);
-			assert_eq!(staker_details.locked_balance, 0);
+			assert_eq!(staker_details.locked_balance, trb(0));
 			assert_eq!(Tellor::get_total_stake_amount(), amount);
 			assert_noop!(
 				Tellor::report_slash(Origin::Governance.into(), 0, 0, (STAKE_AMOUNT + 1).into()),
@@ -334,11 +334,11 @@ fn slash_reporter() {
 			// expect(await tellor.timeOfLastAllocation()).to.equal(blocky0.timestamp)
 			// expect(await tellor.accumulatedRewardPerShare()).to.equal(0)
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(900));
-			assert_eq!(staker_details.locked_balance, 0);
+			assert_eq!(staker_details.staked_balance, trb(900));
+			assert_eq!(staker_details.locked_balance, trb(0));
 			assert!(staker_details.staked);
 			assert_eq!(Tellor::get_total_stakers(), 1); // Still one staker as reporter has 900 staked & stake amount is 100
-			assert_eq!(Tellor::get_total_stake_amount(), token(900));
+			assert_eq!(Tellor::get_total_stake_amount(), trb(900));
 
 			submit_value_and_begin_dispute(reporter, query_id, query_data.clone()) // start dispute, required for slashing
 		});
@@ -354,12 +354,12 @@ fn slash_reporter() {
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(100).into(),
+				trb(100),
 				address
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(800));
-			assert_eq!(staker_details.locked_balance, token(100));
+			assert_eq!(staker_details.staked_balance, trb(800));
+			assert_eq!(staker_details.locked_balance, trb(100));
 			assert!(staker_details.staked);
 			assert_ok!(Tellor::report_slash(
 				Origin::Governance.into(),
@@ -371,10 +371,10 @@ fn slash_reporter() {
 			// expect(await tellor.timeOfLastAllocation()).to.equal(blocky1.timestamp)
 			// expect(await tellor.accumulatedRewardPerShare()).to.equal(0)
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(800));
-			assert_eq!(staker_details.locked_balance, 0);
+			assert_eq!(staker_details.staked_balance, trb(800));
+			assert_eq!(staker_details.locked_balance, trb(0));
 			assert!(staker_details.staked);
-			assert_eq!(Tellor::get_total_stake_amount(), token(800));
+			assert_eq!(Tellor::get_total_stake_amount(), trb(800));
 
 			submit_value_and_begin_dispute(reporter, query_id, query_data.clone()) // start dispute, required for slashing
 		});
@@ -390,13 +390,13 @@ fn slash_reporter() {
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(5).into(),
+				trb(5),
 				address
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(795));
-			assert_eq!(staker_details.locked_balance, token(5));
-			assert_eq!(Tellor::get_total_stake_amount(), token(795));
+			assert_eq!(staker_details.staked_balance, trb(795));
+			assert_eq!(staker_details.locked_balance, trb(5));
+			assert_eq!(Tellor::get_total_stake_amount(), trb(795));
 			assert_ok!(Tellor::report_slash(
 				Origin::Governance.into(),
 				reporter,
@@ -407,36 +407,36 @@ fn slash_reporter() {
 			// expect(await tellor.timeOfLastAllocation()).to.equal(blocky2.timestamp)
 			// expect(await tellor.accumulatedRewardPerShare()).to.equal(0)
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(700));
-			assert_eq!(staker_details.locked_balance, 0);
-			assert_eq!(Tellor::get_total_stake_amount(), token(700));
+			assert_eq!(staker_details.staked_balance, trb(700));
+			assert_eq!(staker_details.locked_balance, trb(0));
+			assert_eq!(Tellor::get_total_stake_amount(), trb(700));
 
 			// Slash when locked balance + staked balance < stake amount
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(625).into(),
+				trb(625),
 				address
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(75));
-			assert_eq!(staker_details.locked_balance, token(625));
-			assert_eq!(Tellor::get_total_stake_amount(), token(75));
+			assert_eq!(staker_details.staked_balance, trb(75));
+			assert_eq!(staker_details.locked_balance, trb(625));
+			assert_eq!(Tellor::get_total_stake_amount(), trb(75));
 		});
 
 		let dispute_id = with_block_after(604_800, || {
 			assert_ok!(Tellor::report_stake_withdrawn(
 				Origin::Staking.into(),
 				reporter,
-				token(625).into(),
+				trb(625),
 				address
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(75));
-			assert_eq!(staker_details.locked_balance, token(0));
+			assert_eq!(staker_details.staked_balance, trb(75));
+			assert_eq!(staker_details.locked_balance, trb(0));
 
 			// reporter now has insufficient stake for another submission, so top up stake before final dispute/slash
-			super::deposit_stake(reporter, STAKE_AMOUNT - token(75), address);
+			super::deposit_stake(reporter, Amount::from(STAKE_AMOUNT) - trb(75), address);
 			submit_value_and_begin_dispute(reporter, query_id, query_data) // start dispute, required for slashing
 		});
 
@@ -457,10 +457,10 @@ fn slash_reporter() {
 			// expect(await tellor.timeOfLastAllocation()).to.equal(blocky.timestamp)
 			// expect(await tellor.accumulatedRewardPerShare()).to.equal(0)
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, 0);
-			assert_eq!(staker_details.locked_balance, 0);
+			assert_eq!(staker_details.staked_balance, trb(0));
+			assert_eq!(staker_details.locked_balance, trb(0));
 			assert_eq!(Tellor::get_total_stakers(), 0);
-			assert_eq!(Tellor::get_total_stake_amount(), 0);
+			assert_eq!(Tellor::get_total_stake_amount(), trb(0));
 		})
 	});
 }
@@ -483,7 +483,7 @@ fn submit_value() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				token(1_200).into(),
+				trb(1_200),
 				address
 			));
 			assert_noop!(
@@ -578,7 +578,7 @@ fn submit_value() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				another_reporter,
-				token(120).into(),
+				trb(120),
 				address
 			));
 			assert_ok!(Tellor::submit_value(
@@ -663,7 +663,7 @@ fn withdraw_stake() {
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(10).into(),
+				trb(10),
 				address
 			));
 			assert_noop!(
@@ -676,27 +676,22 @@ fn withdraw_stake() {
 				Error::WithdrawalPeriodPending
 			);
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(90));
-			assert_eq!(staker_details.locked_balance, token(10));
+			assert_eq!(staker_details.staked_balance, trb(90));
+			assert_eq!(staker_details.locked_balance, trb(10));
 		});
 
 		with_block_after(60 * 60 * 24 * 7, || {
 			assert_ok!(Tellor::report_stake_withdrawn(
 				Origin::Staking.into(),
 				reporter,
-				token(10).into(),
+				trb(10),
 				address
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
-			assert_eq!(staker_details.staked_balance, token(90));
-			assert_eq!(staker_details.locked_balance, 0);
+			assert_eq!(staker_details.staked_balance, trb(90));
+			assert_eq!(staker_details.locked_balance, trb(0));
 			assert_noop!(
-				Tellor::report_stake_withdrawn(
-					Origin::Staking.into(),
-					reporter,
-					token(10).into(),
-					address
-				),
+				Tellor::report_stake_withdrawn(Origin::Staking.into(), reporter, trb(10), address),
 				Error::NoWithdrawalRequested
 			);
 		});
@@ -1025,9 +1020,9 @@ fn get_stake_amount() {
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L439
 	new_test_ext().execute_with(|| {
 		with_block(|| {
-			assert_eq!(Tellor::get_stake_amount(), 0);
+			assert_eq!(Tellor::get_stake_amount(), trb(0));
 			register_parachain(STAKE_AMOUNT);
-			assert_eq!(Tellor::get_stake_amount(), STAKE_AMOUNT);
+			assert_eq!(Tellor::get_stake_amount(), STAKE_AMOUNT.into());
 		})
 	});
 }
@@ -1049,13 +1044,13 @@ fn get_staker_info() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				token(1_000).into(),
+				trb(1_000),
 				address
 			));
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(100).into(),
+				trb(100),
 				address
 			));
 			assert_ok!(Tellor::submit_value(
@@ -1068,8 +1063,8 @@ fn get_staker_info() {
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.address, address);
 			assert_eq!(staker_details.start_date, now());
-			assert_eq!(staker_details.staked_balance, token(900));
-			assert_eq!(staker_details.locked_balance, token(100));
+			assert_eq!(staker_details.staked_balance, trb(900));
+			assert_eq!(staker_details.locked_balance, trb(100));
 			assert_eq!(staker_details.reward_debt, 0);
 			assert_eq!(staker_details.reporter_last_timestamp, now());
 			assert_eq!(staker_details.reports_submitted, 1);
@@ -1217,10 +1212,10 @@ fn get_total_stake_amount() {
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(10).into(),
+				trb(10),
 				address
 			));
-			assert_eq!(Tellor::get_total_stake_amount(), token(90))
+			assert_eq!(Tellor::get_total_stake_amount(), trb(90))
 		});
 	});
 }
@@ -1258,7 +1253,7 @@ fn get_total_stakers() {
 			assert_ok!(Tellor::report_staking_withdraw_request(
 				Origin::Staking.into(),
 				reporter,
-				token(200).into(),
+				trb(200),
 				address
 			));
 			assert_eq!(Tellor::get_total_stakers(), 0);
@@ -1388,7 +1383,7 @@ fn get_index_for_data_before() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				token(1_000).into(),
+				trb(1_000),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -1535,7 +1530,7 @@ fn get_data_before() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				token(1_000).into(),
+				trb(1_000),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,11 +26,11 @@ use sp_runtime::{
 
 pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 pub type Address = H160;
-pub(crate) type Amount = U256;
+pub type Amount = U256;
 pub(crate) type BalanceOf<T> = <T as Config>::Balance;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
 pub type DisputeId = H256;
-pub(crate) type DisputeOf<T> = governance::Dispute<AccountIdOf<T>, AmountOf<T>, ValueOf<T>>;
+pub(crate) type DisputeOf<T> = governance::Dispute<AccountIdOf<T>, ValueOf<T>>;
 pub type FeedId = H256;
 pub(crate) type FeedOf<T> = autopay::Feed<BalanceOf<T>, <T as Config>::MaxRewardClaims>;
 pub(crate) type FeedDetailsOf<T> = autopay::FeedDetails<BalanceOf<T>>;
@@ -135,9 +135,9 @@ pub(crate) mod oracle {
 		/// Stake or withdrawal request start date.
 		pub(crate) start_date: Timestamp,
 		/// Staked token balance
-		pub(crate) staked_balance: Balance,
+		pub(crate) staked_balance: Amount,
 		/// Amount locked for withdrawal.
-		pub(crate) locked_balance: Balance,
+		pub(crate) locked_balance: Amount,
 		/// Used for staking reward calculation.
 		pub(crate) reward_debt: Balance,
 		/// Timestamp of reporter's last reported value.
@@ -159,8 +159,8 @@ pub(crate) mod oracle {
 			Self {
 				address,
 				start_date: Zero::zero(),
-				staked_balance: Zero::zero(),
-				locked_balance: Zero::zero(),
+				staked_balance: Amount::zero(),
+				locked_balance: Amount::zero(),
 				reward_debt: Zero::zero(),
 				reporter_last_timestamp: Zero::zero(),
 				reports_submitted: 0,
@@ -177,7 +177,7 @@ pub(crate) mod governance {
 	use super::*;
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-	pub struct Dispute<AccountId, Amount, Value> {
+	pub struct Dispute<AccountId, Value> {
 		/// Query identifier of disputed value
 		pub(crate) query_id: QueryId,
 		/// Timestamp of disputed value.

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,8 +25,11 @@ use sp_runtime::{
 };
 
 pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+/// Address of a reporter on controller chain.
 pub type Address = H160;
+/// TRB stake amount as reported from controller chain.
 pub type Amount = U256;
+/// Local currency used for onetime tips, funding feeds, accumulated rewards and dispute fees.
 pub(crate) type BalanceOf<T> = <T as Config>::Balance;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
 pub type DisputeId = H256;


### PR DESCRIPTION
Separates stake `Amount` (TRB as reported from controller chain) from `Balance` (native parachain currency used for onetime tips, funding feeds, accumulate rewards and dispute fees).

`U256` used for stake amount due to usage in controller contracts and that reporters can overstake, theoretically exceeding `u128`.

Adds a simple `convert()` function for converting from a stake amount into a local balance, which will be replaced with functionality which performs the conversion based on oracle value.