### PR TITLE
Add staking rewards

### DIFF
--- a/runtime-api/src/governance.rs
+++ b/runtime-api/src/governance.rs
@@ -17,15 +17,15 @@
 use codec::{Decode, Encode};
 
 #[derive(Encode, Debug, Decode, Eq, PartialEq)]
-pub struct VoteInfo<Amount, BlockNumber, Timestamp> {
+pub struct VoteInfo<Balance, BlockNumber, Timestamp> {
 	pub vote_round: u8,
 	pub start_date: Timestamp,
 	pub block_number: BlockNumber,
-	pub fee: Amount,
+	pub fee: Balance,
 	pub tally_date: Timestamp,
-	pub users_does_support: Amount,
-	pub users_against: Amount,
-	pub users_invalid_query: Amount,
+	pub users_does_support: Balance,
+	pub users_against: Balance,
+	pub users_invalid_query: Balance,
 	pub reporters_does_support: u128,
 	pub reporters_against: u128,
 	pub reporters_invalid_query: u128,

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -30,7 +30,7 @@ mod governance;
 mod tests;
 
 sp_api::decl_runtime_apis! {
-	pub trait TellorAutoPay<AccountId: Codec, Amount: Codec>
+	pub trait TellorAutoPay<AccountId: Codec, Balance: Codec>
 	{
 		/// Read current data feeds.
 		/// # Arguments
@@ -44,19 +44,19 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Identifier of reported data.
 		/// # Returns
 		/// Amount of tip.
-		fn get_current_tip(query_id: QueryId) -> Amount;
+		fn get_current_tip(query_id: QueryId) -> Balance;
 
 		/// Read a specific data feed.
 		/// # Arguments
 		/// * `query_id` - Unique feed identifier of parameters.
 		/// # Returns
 		/// Details of the specified feed.
-		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails<Amount>>;
+		fn get_data_feed(feed_id: FeedId) -> Option<FeedDetails<Balance>>;
 
 		/// Read currently funded feed details.
 		/// # Returns
 		/// Details for funded feeds.
-		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData<Amount>>;
+		fn get_funded_feed_details() -> Vec<FeedDetailsWithQueryData<Balance>>;
 
 		/// Read currently funded feeds.
 		/// # Returns
@@ -71,7 +71,7 @@ sp_api::decl_runtime_apis! {
 		/// Read currently funded single tips with query data.
 		/// # Returns
 		/// The current single tips.
-		fn get_funded_single_tips_info() -> Vec<SingleTipWithQueryData<Amount>>;
+		fn get_funded_single_tips_info() -> Vec<SingleTipWithQueryData<Balance>>;
 
 		/// Read the number of past tips for a query identifier.
 		/// # Arguments
@@ -85,7 +85,7 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Identifier of reported data.
 		/// # Returns
 		/// All past tips.
-		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Amount>>;
+		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Balance>>;
 
 		/// Read a past tip for a query identifier and index.
 		/// # Arguments
@@ -93,7 +93,7 @@ sp_api::decl_runtime_apis! {
 		/// * `index` - The index of the tip.
 		/// # Returns
 		/// The past tip, if found.
-		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Amount>>;
+		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Balance>>;
 
 		/// Look up a query identifier from a data feed identifier.
 		/// # Arguments
@@ -109,7 +109,7 @@ sp_api::decl_runtime_apis! {
 		/// * `timestamps` - Timestamps of oracle submissions.
 		/// # Returns
 		/// Potential reward for a set of oracle submissions.
-		fn get_reward_amount(feed_id: FeedId, query_id: QueryId, timestamps: Vec<Timestamp>) -> Amount;
+		fn get_reward_amount(feed_id: FeedId, query_id: QueryId, timestamps: Vec<Timestamp>) -> Balance;
 
 		/// Read whether a reward has been claimed.
 		/// # Arguments
@@ -134,7 +134,7 @@ sp_api::decl_runtime_apis! {
 		/// * `user` - Address of user to query.
 		/// # Returns
 		/// Total amount of tips paid by a user.
-		fn get_tips_by_address(user: AccountId) -> Amount;
+		fn get_tips_by_address(user: AccountId) -> Balance;
 	}
 
 	pub trait TellorOracle<AccountId: Codec, BlockNumber: Codec, StakeInfo: Codec, Value: Codec> where

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -22,7 +22,7 @@ pub use autopay::{FeedDetailsWithQueryData, SingleTipWithQueryData};
 use codec::Codec;
 pub use governance::VoteInfo;
 use sp_std::vec::Vec;
-use tellor::{Amount, DisputeId, FeedDetails, FeedId, QueryId, Timestamp, Tip, VoteResult};
+use tellor::{DisputeId, FeedDetails, FeedId, QueryId, Timestamp, Tip, Tributes, VoteResult};
 
 mod autopay;
 mod governance;
@@ -215,7 +215,7 @@ sp_api::decl_runtime_apis! {
 		/// Returns the amount required to report oracle values.
 		/// # Returns
 		/// The stake amount.
-		fn get_stake_amount() -> Amount;
+		fn get_stake_amount() -> Tributes;
 
 		/// Returns all information about a staker.
 		/// # Arguments
@@ -256,7 +256,7 @@ sp_api::decl_runtime_apis! {
 		/// Returns the total amount staked for reporting.
 		/// # Returns
 		/// The total amount of token staked.
-		fn get_total_stake_amount() -> Amount;
+		fn get_total_stake_amount() -> Tributes;
 
 		/// Returns the total number of current stakers.
 		/// # Returns

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -282,7 +282,7 @@ sp_api::decl_runtime_apis! {
 		fn retrieve_data(query_id: QueryId, timestamp: Timestamp) -> Option<Value>;
 	}
 
-	pub trait TellorGovernance<AccountId: Codec, Amount: Codec, BlockNumber: Codec, Value: Codec> where
+	pub trait TellorGovernance<AccountId: Codec, Balance: Codec, BlockNumber: Codec, Value: Codec> where
 	{
 		/// Determines if an account voted for a specific dispute round.
 		/// # Arguments
@@ -296,7 +296,7 @@ sp_api::decl_runtime_apis! {
 		/// Get the latest dispute fee.
 		/// # Returns
 		/// The latest dispute fee.
-		fn get_dispute_fee() -> Amount;
+		fn get_dispute_fee() -> Option<Balance>;
 
 		/// Returns the dispute identifiers for a reporter.
 		/// # Arguments
@@ -333,7 +333,7 @@ sp_api::decl_runtime_apis! {
 		/// # Returns
 		/// Information on a vote for a given dispute identifier including: the vote identifier, the
 		/// vote information, whether it has been executed, the vote result and the dispute initiator.
-		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<Amount,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)>;
+		fn get_vote_info(dispute_id: DisputeId, vote_round: u8) -> Option<(VoteInfo<Balance,BlockNumber, Timestamp>,bool,Option<VoteResult>,AccountId)>;
 
 		/// Returns the voting rounds for a given dispute identifier.
 		/// # Arguments

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -46,7 +46,7 @@ type AccountId = u64;
 type Balance = u64;
 type BlockNumber = u64;
 type MaxValueLength = ConstU32<4>;
-type StakeInfo = tellor::StakeInfo<Balance, <Test as tellor::Config>::MaxQueriesPerReporter>;
+type StakeInfo = tellor::StakeInfo<<Test as tellor::Config>::MaxQueriesPerReporter>;
 type Value = BoundedVec<u8, MaxValueLength>;
 
 // Configure a mock runtime to test implementation of the runtime-api
@@ -356,7 +356,7 @@ mock_impl_runtime_apis! {
 		}
 
 		fn get_vote_tally_by_address(voter: AccountId) -> u128 {
-			tellor::Pallet::<Test>::get_vote_tally_by_address(voter)
+			tellor::Pallet::<Test>::get_vote_tally_by_address(&voter)
 		}
 	}
 }

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -30,7 +30,7 @@ use sp_core::{ConstU32, H256};
 use sp_runtime::{
 	generic::BlockId,
 	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
+	traits::{BlakeTwo256, Convert, IdentityLookup},
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 use tellor::{
@@ -135,7 +135,7 @@ impl tellor::Config for Test {
 	type StakingOrigin = EnsureStaking;
 	type Time = Time;
 	type Token = Balances;
-	type ValueConverter = ();
+	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
 }
 pub struct TestSendXcm;
@@ -145,6 +145,13 @@ impl tellor::traits::SendXcm for TestSendXcm {
 		_dest: impl Into<MultiLocation>,
 		_message: Xcm<()>,
 	) -> Result<(), SendError> {
+		todo!()
+	}
+}
+
+pub struct ValueConverter;
+impl Convert<Vec<u8>, Result<u32, sp_runtime::DispatchError>> for ValueConverter {
+	fn convert(a: Vec<u8>) -> Result<u32, sp_runtime::DispatchError> {
 		todo!()
 	}
 }

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -46,7 +46,7 @@ type AccountId = u64;
 type Balance = u64;
 type BlockNumber = u64;
 type MaxValueLength = ConstU32<4>;
-type StakeInfo = tellor::StakeInfo<<Test as tellor::Config>::MaxQueriesPerReporter>;
+type StakeInfo = tellor::StakeInfo<Balance, <Test as tellor::Config>::MaxQueriesPerReporter>;
 type Value = BoundedVec<u8, MaxValueLength>;
 
 // Configure a mock runtime to test implementation of the runtime-api
@@ -112,6 +112,7 @@ impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type Balance = Balance;
+	type Decimals = ();
 	type Fee = ();
 	type Governance = ();
 	type GovernanceOrigin = EnsureGovernance;
@@ -311,7 +312,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::did_vote(dispute_id, vote_round, voter)
 		}
 
-		fn get_dispute_fee() -> Balance {
+		fn get_dispute_fee() -> Option<Balance> {
 			tellor::Pallet::<Test>::get_dispute_fee()
 		}
 
@@ -691,7 +692,7 @@ mod governance {
 	#[test]
 	fn get_dispute_fee() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(Test.get_dispute_fee(&BLOCKID).unwrap(), 0);
+			assert_eq!(Test.get_dispute_fee(&BLOCKID).unwrap(), None);
 		});
 	}
 

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -26,7 +26,7 @@ use frame_support::{
 	BoundedVec, PalletId,
 };
 use sp_api::mock_impl_runtime_apis;
-use sp_core::{ConstU32, H256};
+use sp_core::{ConstU32, H256, U256};
 use sp_runtime::{
 	generic::BlockId,
 	testing::Header,
@@ -606,7 +606,7 @@ mod oracle {
 	#[test]
 	fn get_stake_amount() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(Test.get_stake_amount(&BLOCKID).unwrap(), Amount::zero());
+			assert_eq!(Test.get_stake_amount(&BLOCKID).unwrap(), U256::zero());
 		});
 	}
 
@@ -658,7 +658,7 @@ mod oracle {
 	#[test]
 	fn get_total_stake_amount() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(Test.get_total_stake_amount(&BLOCKID).unwrap(), Amount::zero());
+			assert_eq!(Test.get_total_stake_amount(&BLOCKID).unwrap(), U256::zero());
 		});
 	}
 

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -34,8 +34,8 @@ use sp_runtime::{
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 use tellor::{
-	Amount, DisputeId, EnsureGovernance, EnsureStaking, FeedDetails, FeedId, QueryId, Timestamp,
-	Tip, VoteResult,
+	DisputeId, EnsureGovernance, EnsureStaking, FeedDetails, FeedId, QueryId, Timestamp, Tip,
+	Tributes, VoteResult,
 };
 use xcm::latest::prelude::*;
 
@@ -273,7 +273,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_reports_submitted_by_address_and_query_id(reporter, query_id)
 		}
 
-		fn get_stake_amount() -> Amount {
+		fn get_stake_amount() -> Tributes {
 			tellor::Pallet::<Test>::get_stake_amount()
 		}
 
@@ -297,7 +297,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_timestamp_index_by_timestamp(query_id, timestamp)
 		}
 
-		fn get_total_stake_amount() -> Amount {
+		fn get_total_stake_amount() -> Tributes {
 			tellor::Pallet::<Test>::get_total_stake_amount()
 		}
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,4 +24,5 @@ pub(crate) const WEEKS: Timestamp = 7 * DAYS;
 /// Base amount of time before a reporter is able to submit a value again.
 pub(crate) const REPORTING_LOCK: Timestamp = 12 * HOURS;
 
-pub(crate) const UNIT: u128 = 1_000_000_000_000_000_000;
+/// The number of decimals of the TRB token.
+pub(crate) const DECIMALS: u32 = 18;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,3 +23,5 @@ pub(crate) const WEEKS: Timestamp = 7 * DAYS;
 
 /// Base amount of time before a reporter is able to submit a value again.
 pub(crate) const REPORTING_LOCK: Timestamp = 12 * HOURS;
+
+pub(crate) const UNIT: u128 = 1_000_000_000_000_000_000;

--- a/src/contracts/governance.rs
+++ b/src/contracts/governance.rs
@@ -18,11 +18,11 @@ use super::*;
 
 pub(crate) fn begin_parachain_dispute(
 	query_id: &[u8],
-	timestamp: impl Into<Amount>,
+	timestamp: impl Into<U256>,
 	value: &[u8],
-	disputed_reporter: Address,
-	dispute_initiator: Address,
-	slash_amount: impl Into<Amount>,
+	disputed_reporter: H160,
+	dispute_initiator: H160,
+	slash_amount: impl Into<U256>,
 ) -> Vec<u8> {
 	const FUNCTION: [u8; 4] = [29, 93, 54, 159];
 
@@ -38,12 +38,12 @@ pub(crate) fn begin_parachain_dispute(
 
 pub(crate) fn vote(
 	dispute_id: &[u8],
-	total_tips_for: impl Into<Amount>,
-	total_tips_against: impl Into<Amount>,
-	total_tips_invalid: impl Into<Amount>,
-	total_reports_for: impl Into<Amount>,
-	total_reports_against: impl Into<Amount>,
-	total_reports_invalid: impl Into<Amount>,
+	total_tips_for: impl Into<U256>,
+	total_tips_against: impl Into<U256>,
+	total_tips_invalid: impl Into<U256>,
+	total_reports_for: impl Into<U256>,
+	total_reports_against: impl Into<U256>,
+	total_reports_invalid: impl Into<U256>,
 ) -> Vec<u8> {
 	const FUNCTION: [u8; 4] = [61, 181, 167, 166];
 
@@ -101,8 +101,8 @@ mod tests {
 			115, 103, 116, 24, 76, 18, 145, 31, 14, 132, 213, 146, 98, 184, 227, 250, 43, 5, 1, 73,
 			97, 130, 5,
 		];
-		let disputed_reporter = Address::random();
-		let dispute_initiator = Address::random();
+		let disputed_reporter = H160::random();
+		let dispute_initiator = H160::random();
 		let slash_amount = 54321;
 
 		assert_eq!(

--- a/src/contracts/governance.rs
+++ b/src/contracts/governance.rs
@@ -18,11 +18,11 @@ use super::*;
 
 pub(crate) fn begin_parachain_dispute(
 	query_id: &[u8],
-	timestamp: impl Into<U256>,
+	timestamp: impl Into<Amount>,
 	value: &[u8],
 	disputed_reporter: Address,
 	dispute_initiator: Address,
-	slash_amount: impl Into<U256>,
+	slash_amount: impl Into<Amount>,
 ) -> Vec<u8> {
 	const FUNCTION: [u8; 4] = [29, 93, 54, 159];
 
@@ -38,12 +38,12 @@ pub(crate) fn begin_parachain_dispute(
 
 pub(crate) fn vote(
 	dispute_id: &[u8],
-	total_tips_for: impl Into<U256>,
-	total_tips_against: impl Into<U256>,
-	total_tips_invalid: impl Into<U256>,
-	total_reports_for: impl Into<U256>,
-	total_reports_against: impl Into<U256>,
-	total_reports_invalid: impl Into<U256>,
+	total_tips_for: impl Into<Amount>,
+	total_tips_against: impl Into<Amount>,
+	total_tips_invalid: impl Into<Amount>,
+	total_reports_for: impl Into<Amount>,
+	total_reports_against: impl Into<Amount>,
+	total_reports_invalid: impl Into<Amount>,
 ) -> Vec<u8> {
 	const FUNCTION: [u8; 4] = [61, 181, 167, 166];
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::types::{Address, Amount, ParaId};
+use crate::types::ParaId;
+use sp_core::{H160, U256};
 use sp_std::{vec, vec::Vec};
 
 pub(crate) mod governance;
@@ -37,7 +38,7 @@ impl<'a> Call<'a> {
 		Call { function: Vec::new(), parameters: Vec::new() }
 	}
 
-	fn address(mut self, address: Address) -> Self {
+	fn address(mut self, address: H160) -> Self {
 		let mut encoded = [0u8; 32];
 		encoded[12..].copy_from_slice(address.as_fixed_bytes());
 		self.parameters.push(Parameter::Static(encoded));
@@ -56,7 +57,7 @@ impl<'a> Call<'a> {
 		self
 	}
 
-	pub(crate) fn uint(mut self, value: impl Into<Amount>) -> Self {
+	pub(crate) fn uint(mut self, value: impl Into<U256>) -> Self {
 		let mut encoded = [0u8; 32];
 		value.into().to_big_endian(&mut encoded);
 		self.parameters.push(Parameter::Static(encoded));
@@ -74,7 +75,7 @@ impl<'a> Call<'a> {
 					// https://docs.soliditylang.org/en/latest/abi-spec.html#use-of-dynamic-types
 					DynamicParameter::Bytes(_) => {
 						// offset in bytes to start of data area
-						Amount::from(self.parameters.len() * 32).to_big_endian(&mut buffer);
+						U256::from(self.parameters.len() * 32).to_big_endian(&mut buffer);
 						self.function.extend(buffer);
 					},
 				},
@@ -87,7 +88,7 @@ impl<'a> Call<'a> {
 				match parameter {
 					DynamicParameter::Bytes(parameter) => {
 						// Define length
-						Amount::from(parameter.len()).to_big_endian(&mut buffer);
+						U256::from(parameter.len()).to_big_endian(&mut buffer);
 						self.function.extend(buffer);
 
 						// Add data, padding to 32 bytes

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -15,7 +15,6 @@
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::types::{Address, Amount, ParaId};
-use sp_core::U256;
 use sp_std::{vec, vec::Vec};
 
 pub(crate) mod governance;
@@ -57,7 +56,7 @@ impl<'a> Call<'a> {
 		self
 	}
 
-	pub(crate) fn uint(mut self, value: impl Into<U256>) -> Self {
+	pub(crate) fn uint(mut self, value: impl Into<Amount>) -> Self {
 		let mut encoded = [0u8; 32];
 		value.into().to_big_endian(&mut encoded);
 		self.parameters.push(Parameter::Static(encoded));
@@ -75,7 +74,7 @@ impl<'a> Call<'a> {
 					// https://docs.soliditylang.org/en/latest/abi-spec.html#use-of-dynamic-types
 					DynamicParameter::Bytes(_) => {
 						// offset in bytes to start of data area
-						U256::from(self.parameters.len() * 32).to_big_endian(&mut buffer);
+						Amount::from(self.parameters.len() * 32).to_big_endian(&mut buffer);
 						self.function.extend(buffer);
 					},
 				},
@@ -88,7 +87,7 @@ impl<'a> Call<'a> {
 				match parameter {
 					DynamicParameter::Bytes(parameter) => {
 						// Define length
-						U256::from(parameter.len()).to_big_endian(&mut buffer);
+						Amount::from(parameter.len()).to_big_endian(&mut buffer);
 						self.function.extend(buffer);
 
 						// Add data, padding to 32 bytes

--- a/src/contracts/staking.rs
+++ b/src/contracts/staking.rs
@@ -17,8 +17,8 @@
 use super::*;
 
 pub(crate) fn confirm_parachain_stake_withdraw_request(
-	address: impl Into<Address>,
-	amount: impl Into<Amount>,
+	address: impl Into<H160>,
+	amount: impl Into<U256>,
 ) -> Vec<u8> {
 	const FUNCTION: [u8; 4] = [116, 48, 87, 226];
 	Call::new(&FUNCTION).address(address.into()).uint(amount.into()).encode()
@@ -26,7 +26,7 @@ pub(crate) fn confirm_parachain_stake_withdraw_request(
 
 #[cfg(test)]
 mod tests {
-	use super::{super::tests::*, Address};
+	use super::{super::tests::*, H160};
 	use ethabi::{Function, ParamType, Token};
 
 	#[allow(deprecated)]
@@ -54,7 +54,7 @@ mod tests {
 
 	#[test]
 	fn encodes_confirm_parachain_stake_withdraw_request_call() {
-		let staker = Address::random();
+		let staker = H160::random();
 		let amount = 1675711956967u128;
 
 		assert_eq!(

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -61,7 +61,7 @@ impl<T: Config> Pallet<T> {
 	/// * `stake_amount` - The amount staked.
 	/// # Returns
 	/// A stake amount as a local token amount if successful.
-	pub(super) fn convert(stake_amount: Amount) -> Result<U256, DispatchError> {
+	pub(super) fn convert(stake_amount: Tributes) -> Result<U256, DispatchError> {
 		// todo: use rate from oracle
 		const UNIT: u128 = 10u128.pow(DECIMALS);
 		const PRICE: Option<u128> = Some(5 * UNIT); // spot price query uses 18 decimal places as per data spec
@@ -831,7 +831,7 @@ impl<T: Config> Pallet<T> {
 	/// Returns the amount required to report oracle values.
 	/// # Returns
 	/// The stake amount.
-	pub fn get_stake_amount() -> Amount {
+	pub fn get_stake_amount() -> Tributes {
 		<StakeAmount<T>>::get().unwrap_or_default()
 	}
 
@@ -890,7 +890,7 @@ impl<T: Config> Pallet<T> {
 	/// Returns the total amount staked for reporting.
 	/// # Returns
 	/// The total amount of token staked.
-	pub fn get_total_stake_amount() -> Amount {
+	pub fn get_total_stake_amount() -> Tributes {
 		<TotalStakeAmount<T>>::get()
 	}
 
@@ -1169,7 +1169,7 @@ impl<T: Config> Pallet<T> {
 	/// * `new_staked_balance` - The new staked balance of the staker.
 	pub(super) fn update_stake_and_pay_rewards(
 		staker: (&AccountIdOf<T>, &mut StakeInfoOf<T>),
-		new_staked_balance: Amount,
+		new_staked_balance: Tributes,
 	) -> DispatchResult {
 		Self::update_rewards()?;
 		let (staker, stake_info) = staker;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -23,12 +23,16 @@ use sp_runtime::{
 };
 
 impl<T: Config> Pallet<T> {
-	/// Funds the staking account with staking rewards (paid by autopay and minting)
+	/// Funds the staking account with staking rewards from the source account.
 	/// # Arguments
+	/// * `source` - The source account.
 	/// * `amount` - The amount of tokens to fund the staking account with.
-	pub(super) fn add_staking_rewards(amount: BalanceOf<T>) -> DispatchResult {
+	pub(super) fn _add_staking_rewards(
+		source: &AccountIdOf<T>,
+		amount: BalanceOf<T>,
+	) -> DispatchResult {
 		let staking_rewards = Self::staking_rewards();
-		T::Token::transfer(&Self::tips(), &staking_rewards, amount, false)?;
+		T::Token::transfer(source, &staking_rewards, amount, false)?;
 		Self::update_rewards()?;
 		let staking_rewards_balance = T::Token::balance(&staking_rewards).into();
 		// update reward rate = real staking rewards balance / 30 days

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1263,7 +1263,7 @@ pub mod pallet {
 				ensure!(address == staker.address, Error::<T>::InvalidAddress);
 				let staked_balance = staker.staked_balance;
 				let locked_balance = staker.locked_balance;
-				if locked_balance > Amount::zero() {
+				if locked_balance > U256::zero() {
 					if locked_balance >= amount {
 						// if staker's locked balance covers full amount, use that
 						staker.locked_balance = staker.locked_balance.saturating_sub(amount);
@@ -1273,10 +1273,10 @@ pub mod pallet {
 						<ToWithdraw<T>>::mutate(|locked| {
 							*locked = locked.saturating_sub(staker.locked_balance)
 						});
-						staker.locked_balance = Amount::zero();
+						staker.locked_balance = U256::zero();
 					}
 				} else {
-					if staked_balance == Amount::zero() {
+					if staked_balance == U256::zero() {
 						// if staked balance and locked balance equal 0, save current vote tally.
 						// voting participation used for calculating rewards
 						staker.start_vote_count = Self::get_vote_count();
@@ -1369,7 +1369,7 @@ pub mod pallet {
 					Some(staker) => {
 						// Ensure reporter is locked and that enough time has passed
 						ensure!(
-							staker.locked_balance > Amount::zero(),
+							staker.locked_balance > U256::zero(),
 							Error::<T>::NoWithdrawalRequested
 						);
 						ensure!(
@@ -1410,7 +1410,7 @@ pub mod pallet {
 						let staked_balance = staker.staked_balance;
 						let locked_balance = staker.locked_balance;
 						ensure!(
-							staked_balance.saturating_add(locked_balance) > Amount::zero(),
+							staked_balance.saturating_add(locked_balance) > U256::zero(),
 							Error::<T>::InsufficientStake
 						);
 						if locked_balance >= amount {
@@ -1430,17 +1430,14 @@ pub mod pallet {
 							<ToWithdraw<T>>::mutate(|locked| {
 								*locked = locked.saturating_sub(locked_balance)
 							});
-							staker.locked_balance = Amount::zero();
+							staker.locked_balance = U256::zero();
 						} else {
 							// if sum(locked balance + staked balance) is less than stakeAmount, slash sum
 							<ToWithdraw<T>>::mutate(|locked| {
 								*locked = locked.saturating_sub(locked_balance)
 							});
-							Self::update_stake_and_pay_rewards(
-								(&reporter, staker),
-								Amount::zero(),
-							)?;
-							staker.locked_balance = Amount::zero();
+							Self::update_stake_and_pay_rewards((&reporter, staker), U256::zero())?;
+							staker.locked_balance = U256::zero();
 						}
 						Ok(())
 					},
@@ -1470,11 +1467,11 @@ pub mod pallet {
 		#[pallet::call_index(14)]
 		pub fn deregister(origin: OriginFor<T>) -> DispatchResult {
 			T::RegistrationOrigin::ensure_origin(origin)?;
-			ensure!(Self::get_total_stake_amount() == Amount::zero(), Error::<T>::ActiveStake);
+			ensure!(Self::get_total_stake_amount() == U256::zero(), Error::<T>::ActiveStake);
 
 			// Update local configuration
 			<StakeAmount<T>>::set(None);
-			Self::deposit_event(Event::Configured { stake_amount: Amount::zero() });
+			Self::deposit_event(Event::Configured { stake_amount: U256::zero() });
 
 			// Register relevant supplied config with parachain registry contract
 			let config = <Configuration<T>>::take().ok_or(Error::<T>::NotRegistered)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use types::{
 	autopay::{FeedDetails, Tip},
 	governance::VoteResult,
 	oracle::StakeInfo,
-	Address, Amount, DisputeId, FeedId, QueryId, Timestamp,
+	Address, DisputeId, FeedId, QueryId, Timestamp, Tributes,
 };
 
 #[cfg(test)]
@@ -233,7 +233,7 @@ pub mod pallet {
 	pub(super) type RewardRate<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 	/// Minimum amount required to be a staker.
 	#[pallet::storage]
-	pub(super) type StakeAmount<T> = StorageValue<_, Amount>;
+	pub(super) type StakeAmount<T> = StorageValue<_, Tributes>;
 	/// Mapping from a staker's account identifier to their staking info.
 	#[pallet::storage]
 	pub(super) type StakerDetails<T> =
@@ -254,13 +254,13 @@ pub mod pallet {
 	pub(super) type TotalRewardDebt<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 	/// Total amount of tokens locked in the staking controller contract.
 	#[pallet::storage]
-	pub(super) type TotalStakeAmount<T> = StorageValue<_, Amount, ValueQuery>;
+	pub(super) type TotalStakeAmount<T> = StorageValue<_, Tributes, ValueQuery>;
 	/// Total number of stakers with at least StakeAmount staked, not exact.
 	#[pallet::storage]
 	pub(super) type TotalStakers<T> = StorageValue<_, u128, ValueQuery>;
 	/// Amount locked for withdrawal.
 	#[pallet::storage]
-	pub(super) type ToWithdraw<T> = StorageValue<_, Amount, ValueQuery>;
+	pub(super) type ToWithdraw<T> = StorageValue<_, Tributes, ValueQuery>;
 	// Governance
 	#[pallet::storage]
 	pub(super) type DisputeIdsByReporter<T> =
@@ -333,13 +333,17 @@ pub mod pallet {
 			reporter: AccountIdOf<T>,
 		},
 		/// Emitted when a new staker is reported.
-		NewStakerReported { staker: AccountIdOf<T>, amount: Amount, address: Address },
+		NewStakerReported { staker: AccountIdOf<T>, amount: Tributes, address: Address },
 		/// Emitted when a stake slash is reported.
-		SlashReported { reporter: AccountIdOf<T>, recipient: AccountIdOf<T>, amount: Amount },
+		SlashReported { reporter: AccountIdOf<T>, recipient: AccountIdOf<T>, amount: Tributes },
 		/// Emitted when a stake withdrawal is reported.
 		StakeWithdrawnReported { staker: AccountIdOf<T> },
 		/// Emitted when a stake withdrawal request is reported.
-		StakeWithdrawRequestReported { reporter: AccountIdOf<T>, amount: Amount, address: Address },
+		StakeWithdrawRequestReported {
+			reporter: AccountIdOf<T>,
+			amount: Tributes,
+			address: Address,
+		},
 		/// Emitted when a value is removed (via governance).
 		ValueRemoved { query_id: QueryId, timestamp: Timestamp },
 
@@ -364,7 +368,7 @@ pub mod pallet {
 
 		// Registration
 		/// Emitted when the pallet is (re-)configured.
-		Configured { stake_amount: Amount },
+		Configured { stake_amount: Tributes },
 		/// Emitted when registration with the controller contracts is attempted.
 		RegistrationAttempted { para_id: u32, contract_address: Address },
 		/// Emitted when deregistration from the controller contracts is attempted.
@@ -516,7 +520,7 @@ pub mod pallet {
 		#[pallet::call_index(0)]
 		pub fn register(
 			origin: OriginFor<T>,
-			stake_amount: Amount,
+			stake_amount: Tributes,
 			fees: Box<MultiAsset>,
 			weight_limit: WeightLimit,
 			require_weight_at_most: u64,
@@ -1252,7 +1256,7 @@ pub mod pallet {
 		pub fn report_stake_deposited(
 			origin: OriginFor<T>,
 			reporter: AccountIdOf<T>,
-			amount: Amount,
+			amount: Tributes,
 			address: Address,
 		) -> DispatchResult {
 			// ensure origin is staking controller contract
@@ -1304,7 +1308,7 @@ pub mod pallet {
 		pub fn report_staking_withdraw_request(
 			origin: OriginFor<T>,
 			reporter: AccountIdOf<T>,
-			amount: Amount,
+			amount: Tributes,
 			address: Address,
 		) -> DispatchResult {
 			// ensure origin is staking controller contract
@@ -1356,7 +1360,7 @@ pub mod pallet {
 		pub fn report_stake_withdrawn(
 			origin: OriginFor<T>,
 			reporter: AccountIdOf<T>,
-			amount: Amount,
+			amount: Tributes,
 			// todo: consider removal of address
 			address: Address,
 		) -> DispatchResult {
@@ -1398,7 +1402,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			reporter: AccountIdOf<T>,
 			recipient: AccountIdOf<T>,
-			amount: Amount,
+			amount: Tributes,
 		) -> DispatchResult {
 			// ensure origin is governance controller contract
 			T::GovernanceOrigin::ensure_origin(origin)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,10 +240,6 @@ pub mod pallet {
 		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, StakeInfoOf<T>>;
 	#[pallet::storage]
 	pub(super) type StakerAddresses<T> = StorageMap<_, Blake2_128Concat, Address, AccountIdOf<T>>;
-	/// Total amount of staking rewards.
-	#[pallet::storage]
-	#[pallet::getter(fn staking_rewards_balance)]
-	pub(super) type StakingRewardsBalance<T> = StorageValue<_, BalanceOf<T>, ValueQuery>; // todo: replace with T::Token::balance(staking_account)
 	/// The time of last update to AccumulatedRewardPerShare.
 	#[pallet::storage]
 	#[pallet::getter(fn time_of_last_allocation)]

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -23,7 +23,7 @@ use frame_support::{
 };
 use frame_system as system;
 use once_cell::sync::Lazy;
-use sp_core::{ConstU32, H256};
+use sp_core::{ConstU32, ConstU8, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup},
@@ -35,7 +35,7 @@ use std::{
 };
 use xcm::latest::prelude::*;
 
-pub(crate) type AccountId = u128; // u64 is not enough to hold bytes used to generate bounty account
+pub(crate) type AccountId = u128; // u64 is not enough to hold bytes used to generate sub accounts
 type Balance = u64;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -121,6 +121,7 @@ impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type Balance = Balance;
+	type Decimals = ConstU8<12>;
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -24,6 +24,8 @@ type BoundedVotes = BoundedBTreeMap<AccountId, bool, <Test as Config>::MaxVotes>
 type ParachainId = <Test as Config>::ParachainId;
 type VoteRounds = crate::pallet::VoteRounds<Test>;
 
+const PRICE: Balance = 5; // 1 TRB = 5 UNIT (uses static price for now)
+
 #[test]
 fn begin_dispute() {
 	let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
@@ -116,7 +118,7 @@ fn begin_dispute() {
 				balance_before_begin_dispute -
 					balance_after_begin_dispute -
 					U256ToBalance::convert(
-						Tellor::convert(StakeAmount::<Test>::get().unwrap()).unwrap()
+						Tellor::convert(StakeAmount::<Test>::get().unwrap()).unwrap() * PRICE
 					) / 10 == 0,
 				"dispute fee paid should be correct"
 			);
@@ -274,7 +276,7 @@ fn begin_dispute_by_non_reporter() {
 				balance_before_begin_dispute -
 					balance_after_begin_dispute -
 					U256ToBalance::convert(
-						Tellor::convert(StakeAmount::<Test>::get().unwrap()).unwrap()
+						Tellor::convert(StakeAmount::<Test>::get().unwrap()).unwrap() * PRICE
 					) / 10 == 0,
 				"dispute fee paid should be correct"
 			);

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -736,12 +736,12 @@ fn vote() {
 			assert!(!Tellor::did_vote(dispute_id, 1, 3), "voter's voted status should be correct");
 
 			assert_eq!(
-				Tellor::get_vote_tally_by_address(reporter_2),
+				Tellor::get_vote_tally_by_address(&reporter_2),
 				1,
 				"vote tally by address should be correct"
 			);
 			assert_eq!(
-				Tellor::get_vote_tally_by_address(reporter_1),
+				Tellor::get_vote_tally_by_address(&reporter_1),
 				1,
 				"vote tally by address should be correct"
 			);
@@ -1264,19 +1264,19 @@ fn get_vote_tally_by_address() {
 			let dispute_id_2 = super::dispute_id(PARA_ID, query_id, now());
 
 			assert_eq!(
-				Tellor::get_vote_tally_by_address(reporter),
+				Tellor::get_vote_tally_by_address(&reporter),
 				0,
 				"vote tally should be correct"
 			);
 			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), dispute_id, Some(false)));
 			assert_eq!(
-				Tellor::get_vote_tally_by_address(reporter),
+				Tellor::get_vote_tally_by_address(&reporter),
 				1,
 				"vote tally should be correct"
 			);
 			assert_ok!(Tellor::vote(RuntimeOrigin::signed(reporter), dispute_id_2, Some(false)));
 			assert_eq!(
-				Tellor::get_vote_tally_by_address(reporter),
+				Tellor::get_vote_tally_by_address(&reporter),
 				2,
 				"vote tally should be correct"
 			);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 	mock,
 	mock::*,
 	types::{
-		AccountIdOf, Address, Amount, BalanceOf, DisputeId, QueryDataOf, QueryId, Timestamp,
+		AccountIdOf, Address, BalanceOf, DisputeId, QueryDataOf, QueryId, Timestamp, Tributes,
 		ValueOf,
 	},
 	xcm::{ethereum_xcm, XcmConfig},
@@ -53,9 +53,9 @@ const PRICE: Balance = 5; // 1 TRB = 5 UNIT (uses static price for now)
 const STAKE_AMOUNT: u128 = 100 * TRB;
 const TRB: u128 = 10u128.pow(DECIMALS);
 
-fn trb(amount: impl Into<f64>) -> Amount {
+fn trb(amount: impl Into<f64>) -> Tributes {
 	// TRB amount has 18 decimals
-	Amount::from((amount.into() * TRB as f64) as u128)
+	Tributes::from((amount.into() * TRB as f64) as u128)
 }
 
 fn dispute_id(para_id: u32, query_id: QueryId, timestamp: Timestamp) -> DisputeId {
@@ -92,7 +92,7 @@ fn submit_value_and_begin_dispute(
 	}
 }
 
-fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<Amount>, address: Address) {
+fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<Tributes>, address: Address) {
 	assert_ok!(Tellor::report_stake_deposited(
 		Origin::Staking.into(),
 		reporter,
@@ -101,7 +101,7 @@ fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<Amount>, address
 	));
 }
 
-fn register_parachain(stake_amount: impl Into<Amount>) {
+fn register_parachain(stake_amount: impl Into<Tributes>) {
 	let self_reserve = MultiLocation { parents: 0, interior: X1(PalletInstance(3)) };
 	assert_ok!(Tellor::register(
 		RuntimeOrigin::root(),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -43,12 +43,12 @@ type Config = crate::types::Configuration;
 type Configuration = crate::pallet::Configuration<Test>;
 type Error = crate::Error<Test>;
 
-const STAKE_AMOUNT: u128 = 100_000_000_000_000_000_000;
+const STAKE_AMOUNT: u128 = 100_000_000_000_000_000_000; // 100 TRB
 
 fn trb(amount: impl Into<f64>) -> Amount {
 	// TRB amount has 18 decimals
-	const UNIT: u128 = 1_000_000_000_000_000_000;
-	Amount::from((amount.into() * UNIT as f64) as u128)
+	const UNIT: f64 = 1_000_000_000_000_000_000.0;
+	Amount::from((amount.into() * UNIT) as u128)
 }
 
 fn dispute_id(para_id: u32, query_id: QueryId, timestamp: Timestamp) -> DisputeId {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -32,7 +32,10 @@ use frame_support::{
 	traits::{Get, PalletInfoAccess, UnixTime},
 };
 use sp_core::{bytes::to_hex, keccak_256, H256};
-use sp_runtime::traits::{AccountIdConversion, BadOrigin};
+use sp_runtime::{
+	traits::{AccountIdConversion, BadOrigin},
+	ArithmeticError,
+};
 use std::convert::Into;
 use xcm::{latest::prelude::*, DoubleEncoded};
 
@@ -186,18 +189,21 @@ fn encodes_spot_price() {
 fn redenominates() {
 	assert_eq!(
 		Tellor::redenominate((100 * 10u128.pow(18)).into(), 12),
-		Some((100 * 10u64.pow(12)).into())
+		Ok((100 * 10u64.pow(12)).into())
 	);
 	assert_eq!(
 		Tellor::redenominate((100 * 10u128.pow(18)).into(), 20),
-		Some((100 * 10u128.pow(20)).into())
+		Ok((100 * 10u128.pow(20)).into())
 	);
 	assert_eq!(
 		Tellor::redenominate((100 * 10u128.pow(18)).into(), 18),
-		Some((100 * 10u128.pow(18)).into())
+		Ok((100 * 10u128.pow(18)).into())
 	);
-	assert_eq!(Tellor::redenominate((100 * 10u128.pow(18)).into(), 0), Some(100.into()));
-	assert_eq!(Tellor::redenominate((100 * 10u128.pow(18)).into(), u8::MAX.into()), None);
+	assert_eq!(Tellor::redenominate((100 * 10u128.pow(18)).into(), 0), Ok(100.into()));
+	assert_eq!(
+		Tellor::redenominate((100 * 10u128.pow(18)).into(), u8::MAX.into()),
+		Err(ArithmeticError::Overflow.into())
+	);
 }
 
 #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -49,7 +49,6 @@ type Configuration = crate::pallet::Configuration<Test>;
 type Error = crate::Error<Test>;
 type U256ToBalance = crate::types::U256ToBalance<Test>;
 
-const PRICE: Balance = 5; // 1 TRB = 5 UNIT (uses static price for now)
 const STAKE_AMOUNT: u128 = 100 * TRB;
 const TRB: u128 = 10u128.pow(DECIMALS);
 
@@ -166,7 +165,7 @@ fn converts_token() {
 
 #[test]
 fn converts() {
-	assert_eq!(Tellor::convert(trb(100)).unwrap(), (token(100) * PRICE).into())
+	assert_eq!(Tellor::convert(trb(100)).unwrap(), token(100).into())
 }
 
 #[test]

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -435,7 +435,7 @@ fn slash_reporter() {
 			assert_eq!(staker_details.locked_balance, trb(0));
 
 			// reporter now has insufficient stake for another submission, so top up stake before final dispute/slash
-			super::deposit_stake(reporter, Amount::from(STAKE_AMOUNT) - trb(75), address);
+			super::deposit_stake(reporter, Tributes::from(STAKE_AMOUNT) - trb(75), address);
 			submit_value_and_begin_dispute(reporter, query_id, query_data) // start dispute, required for slashing
 		});
 

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -16,14 +16,14 @@
 
 use super::*;
 use crate::{
-	constants::{REPORTING_LOCK, UNIT},
-	types::{Nonce, QueryId, Timestamp, U256ToBalance},
+	constants::REPORTING_LOCK,
+	types::{Nonce, QueryId, Timestamp},
 	Config,
 };
 use frame_support::{assert_noop, assert_ok, traits::Currency};
 use sp_core::{bounded::BoundedBTreeMap, bounded_btree_map, bounded_vec, U256};
 use sp_runtime::{
-	traits::{AccountIdConversion, BadOrigin, Convert},
+	traits::{AccountIdConversion, BadOrigin},
 	SaturatedConversion,
 };
 
@@ -69,14 +69,14 @@ fn deposit_stake() {
 			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.staked_balance, amount);
 			assert_eq!(staker_details.locked_balance, trb(0));
-			assert_eq!(staker_details.reward_debt, trb(0));
+			assert_eq!(staker_details.reward_debt, 0);
 			assert_eq!(staker_details.reporter_last_timestamp, 0);
 			assert_eq!(staker_details.reports_submitted, 0);
 			assert_eq!(staker_details.start_vote_count, 0);
 			assert_eq!(staker_details.start_vote_tally, 0);
 			assert_eq!(staker_details.staked, true);
 			assert!(staker_details.reports_submitted_by_query_id.is_empty());
-			assert_eq!(Tellor::total_reward_debt(), Amount::zero());
+			assert_eq!(Tellor::total_reward_debt(), 0);
 			assert_eq!(Tellor::get_total_stake_amount(), amount);
 
 			// Test min value for amount argument
@@ -214,7 +214,7 @@ fn request_stake_withdraw() {
 			assert_eq!(staker_details.locked_balance, trb(0));
 			assert_eq!(staker_details.staked, true);
 			assert_eq!(Tellor::get_total_stake_amount(), amount);
-			assert_eq!(Tellor::total_reward_debt(), Amount::zero());
+			assert_eq!(Tellor::total_reward_debt(), 0);
 			assert_noop!(
 				Tellor::report_staking_withdraw_request(
 					Origin::Staking.into(),
@@ -233,12 +233,12 @@ fn request_stake_withdraw() {
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.start_date, now());
-			assert_eq!(staker_details.reward_debt, trb(0));
+			assert_eq!(staker_details.reward_debt, 0);
 			assert_eq!(staker_details.staked_balance, trb(990));
 			assert_eq!(staker_details.locked_balance, trb(10));
 			assert_eq!(staker_details.staked, true);
 			assert_eq!(Tellor::get_total_stake_amount(), trb(990));
-			assert_eq!(Tellor::total_reward_debt(), trb(0));
+			assert_eq!(Tellor::total_reward_debt(), 0);
 
 			// Test max/min for amount arg
 			assert_noop!(
@@ -258,12 +258,12 @@ fn request_stake_withdraw() {
 			));
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.start_date, now());
-			assert_eq!(staker_details.reward_debt, trb(0));
+			assert_eq!(staker_details.reward_debt, 0);
 			assert_eq!(staker_details.staked_balance, trb(990));
 			assert_eq!(staker_details.locked_balance, trb(10));
 			assert_eq!(staker_details.staked, true);
 			assert_eq!(Tellor::get_total_stake_amount(), trb(990));
-			assert_eq!(Tellor::total_reward_debt(), trb(0));
+			assert_eq!(Tellor::total_reward_debt(), 0);
 
 			assert_eq!(Tellor::get_total_stakers(), 1);
 			assert_ok!(Tellor::report_staking_withdraw_request(
@@ -333,7 +333,7 @@ fn slash_reporter() {
 			));
 
 			assert_eq!(Tellor::time_of_last_allocation(), now());
-			assert_eq!(Tellor::accumulated_reward_per_share(), Amount::zero());
+			assert_eq!(Tellor::accumulated_reward_per_share(), 0);
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.staked_balance, trb(900));
 			assert_eq!(staker_details.locked_balance, trb(0));
@@ -369,7 +369,7 @@ fn slash_reporter() {
 				STAKE_AMOUNT.into()
 			));
 			assert_eq!(Tellor::time_of_last_allocation(), now());
-			assert_eq!(Tellor::accumulated_reward_per_share(), trb(0));
+			assert_eq!(Tellor::accumulated_reward_per_share(), 0);
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.staked_balance, trb(800));
 			assert_eq!(staker_details.locked_balance, trb(0));
@@ -404,7 +404,7 @@ fn slash_reporter() {
 				STAKE_AMOUNT.into()
 			));
 			assert_eq!(Tellor::time_of_last_allocation(), now());
-			assert_eq!(Tellor::accumulated_reward_per_share(), trb(0));
+			assert_eq!(Tellor::accumulated_reward_per_share(), 0);
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.staked_balance, trb(700));
 			assert_eq!(staker_details.locked_balance, trb(0));
@@ -453,7 +453,7 @@ fn slash_reporter() {
 				STAKE_AMOUNT.into()
 			));
 			assert_eq!(Tellor::time_of_last_allocation(), now());
-			assert_eq!(Tellor::accumulated_reward_per_share(), trb(0));
+			assert_eq!(Tellor::accumulated_reward_per_share(), 0);
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.staked_balance, trb(0));
 			assert_eq!(staker_details.locked_balance, trb(0));
@@ -1063,7 +1063,7 @@ fn get_staker_info() {
 			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.staked_balance, trb(900));
 			assert_eq!(staker_details.locked_balance, trb(100));
-			assert_eq!(staker_details.reward_debt, trb(0));
+			assert_eq!(staker_details.reward_debt, 0);
 			assert_eq!(staker_details.reporter_last_timestamp, now());
 			assert_eq!(staker_details.reports_submitted, 1);
 			assert_eq!(staker_details.start_vote_count, 0);
@@ -1381,20 +1381,14 @@ fn add_staking_rewards() {
 		assert_eq!(Balances::free_balance(staking_account), token(1_000));
 		assert_eq!(Tellor::staking_rewards_balance(), token(1_000));
 		assert_eq!(Balances::free_balance(pallet_account), 0);
-		assert_eq!(
-			Tellor::reward_rate(),
-			Amount::from(token(1_000)) / Amount::from(REWARD_RATE_TARGET)
-		);
+		assert_eq!(Tellor::reward_rate(), token(1_000) / REWARD_RATE_TARGET);
 
 		// Test min value
 		assert_ok!(Tellor::add_staking_rewards(0));
 		assert_eq!(Balances::free_balance(staking_account), token(1_000));
 		assert_eq!(Tellor::staking_rewards_balance(), token(1_000));
 		assert_eq!(Balances::free_balance(pallet_account), 0);
-		assert_eq!(
-			Tellor::reward_rate(),
-			Amount::from(token(1_000)) / Amount::from(REWARD_RATE_TARGET)
-		);
+		assert_eq!(Tellor::reward_rate(), token(1_000) / REWARD_RATE_TARGET);
 	});
 }
 
@@ -1721,6 +1715,7 @@ fn update_rewards() {
 	let reporter = 1;
 	let address = Address::random();
 	let pallet_account = &<Test as Config>::PalletId::get().into_account_truncating();
+	let unit = unit();
 	let mut ext = new_test_ext();
 
 	// Prerequisites
@@ -1734,8 +1729,8 @@ fn update_rewards() {
 
 			let timestamp = now();
 			assert_eq!(Tellor::time_of_last_allocation(), timestamp);
-			assert_eq!(Tellor::accumulated_reward_per_share(), trb(0));
-			assert_eq!(Tellor::reward_rate(), trb(0));
+			assert_eq!(Tellor::accumulated_reward_per_share(), 0);
+			assert_eq!(Tellor::reward_rate(), 0);
 			timestamp
 		});
 
@@ -1752,8 +1747,8 @@ fn update_rewards() {
 			let timestamp = now();
 			assert_eq!(timestamp, timestamp_0 + 1);
 			assert_eq!(Tellor::time_of_last_allocation(), timestamp);
-			assert_eq!(Tellor::accumulated_reward_per_share(), trb(0));
-			assert_eq!(Tellor::reward_rate(), trb(0));
+			assert_eq!(Tellor::accumulated_reward_per_share(), 0);
+			assert_eq!(Tellor::reward_rate(), 0);
 			timestamp
 		});
 
@@ -1769,13 +1764,13 @@ fn update_rewards() {
 			let timestamp = now();
 			assert_eq!(timestamp, timestamp_0 + 1);
 			assert_eq!(Tellor::time_of_last_allocation(), timestamp);
-			assert_eq!(Tellor::accumulated_reward_per_share(), trb(0));
-			assert_eq!(Tellor::reward_rate(), trb(0));
+			assert_eq!(Tellor::accumulated_reward_per_share(), 0);
+			assert_eq!(Tellor::reward_rate(), 0);
 			timestamp
 		});
 
-		let staking_rewards = trb(1_000).saturated_into();
-		let expected_reward_rate = Amount::from(staking_rewards / (86_400 * 30));
+		let staking_rewards = token(1_000);
+		let expected_reward_rate = staking_rewards / (86_400 * 30);
 		let timestamp_1 = with_block(|| {
 			// add staking rewards
 			assert_eq!(Tellor::staking_rewards_balance(), 0);
@@ -1784,9 +1779,9 @@ fn update_rewards() {
 			let timestamp = now();
 			assert_eq!(timestamp, timestamp_0 + 1);
 			assert_eq!(Tellor::time_of_last_allocation(), timestamp);
-			assert_eq!(Tellor::accumulated_reward_per_share(), trb(0));
+			assert_eq!(Tellor::accumulated_reward_per_share(), 0);
 			assert_eq!(Tellor::staking_rewards_balance(), staking_rewards);
-			assert_eq!(Tellor::total_reward_debt(), trb(0));
+			assert_eq!(Tellor::total_reward_debt(), 0);
 			assert_eq!(Tellor::reward_rate(), expected_reward_rate);
 			timestamp
 		});
@@ -1800,44 +1795,47 @@ fn update_rewards() {
 			assert_eq!(timestamp, timestamp_1 + 86_400 + 1);
 			assert_eq!(Tellor::time_of_last_allocation(), timestamp);
 			assert_eq!(Tellor::staking_rewards_balance(), staking_rewards);
-			assert_eq!(Tellor::total_reward_debt(), trb(0));
+			assert_eq!(Tellor::total_reward_debt(), 0);
 			assert_eq!(Tellor::reward_rate(), expected_reward_rate);
 			// expAccumRewPerShare = BigInt(blocky2.timestamp - blocky1.timestamp) * BigInt(expectedRewardRate) * BigInt(1e18) / BigInt(100e18)
-			let expected_accumulated_reward_per_share = Amount::from(timestamp - timestamp_1) *
-				expected_reward_rate *
-				Amount::from(10u128.pow(18)) /
-				Amount::from(10u128.pow(20));
+			let expected_accumulated_reward_per_share = u128::from(timestamp - timestamp_1) *
+				u128::from(expected_reward_rate) *
+				unit / (100 * unit * PRICE as u128);
 			assert_eq!(
 				Tellor::accumulated_reward_per_share(),
-				expected_accumulated_reward_per_share
+				expected_accumulated_reward_per_share.saturated_into::<Balance>()
 			);
 			(timestamp, expected_accumulated_reward_per_share)
 		});
 
 		let timestamp_3 = with_block(|| {
 			// deposit another stake
-			assert_ok!(Tellor::report_stake_deposited(
-				Origin::Staking.into(),
-				reporter,
-				trb(50),
-				address
-			));
+			// todo:
+			// assert_ok!(Tellor::report_stake_deposited(
+			// 	Origin::Staking.into(),
+			// 	reporter,
+			// 	trb(50),
+			// 	address
+			// ));
 			assert_ok!(Tellor::update_rewards());
 
 			let timestamp = now();
 			assert_eq!(Tellor::time_of_last_allocation(), timestamp);
 			assert_eq!(Tellor::reward_rate(), expected_reward_rate);
 			let expected_accumulated_reward_per_share = expected_accumulated_reward_per_share +
-				(Amount::from(timestamp - timestamp_2) *
-					expected_reward_rate * Amount::from(UNIT) /
-					Amount::from(10u128.pow(20)));
+				(u128::from(timestamp - timestamp_2) * u128::from(expected_reward_rate) * unit /
+					(100 * unit * PRICE as u128));
 			assert_eq!(
 				Tellor::accumulated_reward_per_share(),
-				expected_accumulated_reward_per_share
+				expected_accumulated_reward_per_share.saturated_into::<Balance>()
 			);
-			let expected_staking_rewards_balance = staking_rewards -
-				<U256ToBalance<Test>>::convert(expected_accumulated_reward_per_share * 100);
-			assert_eq!(Tellor::staking_rewards_balance(), expected_staking_rewards_balance);
+			// todo:
+			// let expected_staking_rewards_balance = U256ToBalance::convert(
+			// 	Amount::from(staking_rewards) -
+			// 		(Amount::from(expected_accumulated_reward_per_share) *
+			// 			Amount::from(token(100))),
+			// );
+			//assert_eq!(Tellor::staking_rewards_balance(), expected_staking_rewards_balance);
 			timestamp
 		});
 
@@ -1850,11 +1848,11 @@ fn update_rewards() {
 
 				assert_eq!(timestamp, timestamp_3 + 86_400 * 30 + 1);
 				assert_eq!(Tellor::time_of_last_allocation(), timestamp);
-				assert_eq!(Tellor::reward_rate(), trb(0)); // rewards ran out, reward rate should be 0
-				let expected_accumulated_reward_per_share = trb(1000) / Amount::from(100u128);
+				assert_eq!(Tellor::reward_rate(), 0); // rewards ran out, reward rate should be 0
+				let expected_accumulated_reward_per_share = token(1000) / (100 * PRICE);
 				assert_eq!(
 					Tellor::accumulated_reward_per_share(),
-					expected_accumulated_reward_per_share.into()
+					expected_accumulated_reward_per_share
 				);
 				(timestamp, expected_accumulated_reward_per_share)
 			});
@@ -1866,12 +1864,12 @@ fn update_rewards() {
 			let timestamp = now();
 
 			// checks, should be no change
-			assert_eq!(timestamp, timestamp_1 + 86_400 + 1);
-			assert_eq!(Tellor::time_of_last_allocation(), timestamp_4); // should update to latest updateRewards ts
-			assert_eq!(Tellor::reward_rate(), trb(0)); // should still be zero
+			assert_eq!(timestamp, timestamp_4 + 86_400 + 1);
+			assert_eq!(Tellor::time_of_last_allocation(), timestamp); // should update to latest updateRewards ts
+			assert_eq!(Tellor::reward_rate(), 0); // should still be zero
 
 			assert_eq!(Tellor::staking_rewards_balance(), staking_rewards);
-			assert_eq!(Tellor::total_reward_debt(), trb(0));
+			assert_eq!(Tellor::total_reward_debt(), 0);
 			assert_eq!(
 				Tellor::accumulated_reward_per_share(),
 				expected_accumulated_reward_per_share

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -1955,9 +1955,9 @@ fn update_stake_and_pay_rewards() {
 				let expected_accumulated_reward_per_share =
 					(timestamp - timestamp_0) * expected_reward_rate / (10 * PRICE);
 				let expected_balance = U256ToBalance::convert(
-					Amount::from(token(10) * PRICE) *
-						Amount::from(expected_accumulated_reward_per_share) /
-						Amount::from(token(1)),
+					U256::from(token(10) * PRICE) *
+						U256::from(expected_accumulated_reward_per_share) /
+						U256::from(token(1)),
 				);
 				assert_eq!(Balances::free_balance(1), expected_balance);
 				assert_eq!(

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -1807,7 +1807,7 @@ fn update_rewards() {
 			// expAccumRewPerShare = BigInt(blocky2.timestamp - blocky1.timestamp) * BigInt(expectedRewardRate) * BigInt(1e18) / BigInt(100e18)
 			let expected_accumulated_reward_per_share = u128::from(timestamp - timestamp_1) *
 				u128::from(expected_reward_rate) *
-				unit / (100 * unit * PRICE as u128);
+				unit / (100 * unit);
 			assert_eq!(
 				Tellor::accumulated_reward_per_share(),
 				expected_accumulated_reward_per_share.saturated_into::<Balance>()
@@ -1831,7 +1831,7 @@ fn update_rewards() {
 			assert_eq!(Tellor::reward_rate(), expected_reward_rate);
 			let expected_accumulated_reward_per_share = expected_accumulated_reward_per_share +
 				(u128::from(timestamp - timestamp_2) * u128::from(expected_reward_rate) * unit /
-					(100 * unit * PRICE as u128));
+					(100 * unit));
 			assert_eq!(
 				Tellor::accumulated_reward_per_share(),
 				expected_accumulated_reward_per_share.saturated_into::<Balance>()
@@ -1856,7 +1856,7 @@ fn update_rewards() {
 				assert_eq!(timestamp, timestamp_3 + 86_400 * 30 + 1);
 				assert_eq!(Tellor::time_of_last_allocation(), timestamp);
 				assert_eq!(Tellor::reward_rate(), 0); // rewards ran out, reward rate should be 0
-				let expected_accumulated_reward_per_share = token(1000) / (100 * PRICE);
+				let expected_accumulated_reward_per_share = token(1000) / 100;
 				assert_eq!(
 					Tellor::accumulated_reward_per_share(),
 					expected_accumulated_reward_per_share
@@ -1962,10 +1962,9 @@ fn update_stake_and_pay_rewards() {
 				assert_eq!(Tellor::time_of_last_allocation(), timestamp);
 				assert_eq!(Tellor::reward_rate(), expected_reward_rate);
 				let expected_accumulated_reward_per_share =
-					(timestamp - timestamp_0) * expected_reward_rate / (10 * PRICE);
+					(timestamp - timestamp_0) * expected_reward_rate / 10;
 				let expected_balance = U256ToBalance::convert(
-					U256::from(token(10) * PRICE) *
-						U256::from(expected_accumulated_reward_per_share) /
+					U256::from(token(10)) * U256::from(expected_accumulated_reward_per_share) /
 						U256::from(token(1)),
 				);
 				assert_eq!(Balances::free_balance(1), expected_balance);
@@ -2000,14 +1999,14 @@ fn update_stake_and_pay_rewards() {
 				assert_eq!(Tellor::time_of_last_allocation(), timestamp);
 				assert_eq!(Tellor::reward_rate(), expected_reward_rate);
 				let expected_accumulated_reward_per_share = ((timestamp - timestamp_1) *
-					expected_reward_rate / (10 * PRICE)) +
+					expected_reward_rate / 10) +
 					expected_accumulated_reward_per_share;
 				assert_eq!(Balances::free_balance(1), expected_balance);
 				assert_eq!(
 					Tellor::accumulated_reward_per_share(),
 					expected_accumulated_reward_per_share
 				);
-				let expected_reward_debt = expected_accumulated_reward_per_share * (10 * PRICE);
+				let expected_reward_debt = expected_accumulated_reward_per_share * 10;
 				assert_eq!(Tellor::total_reward_debt(), expected_reward_debt);
 				let staker_info = Tellor::get_staker_info(reporter).unwrap();
 				assert_eq!(staker_info.staked_balance, trb(10)); // staked balance
@@ -2034,18 +2033,17 @@ fn update_stake_and_pay_rewards() {
 			// check conditions after updating rewards
 			assert_eq!(Tellor::time_of_last_allocation(), timestamp);
 			assert_eq!(Tellor::reward_rate(), expected_reward_rate);
-			let expected_accumulated_reward_per_share =
-				((timestamp - timestamp_2) * expected_reward_rate / (10 * PRICE)) +
-					expected_accumulated_reward_per_share;
+			let expected_accumulated_reward_per_share = ((timestamp - timestamp_2) *
+				expected_reward_rate /
+				10) + expected_accumulated_reward_per_share;
 			let expected_balance = expected_balance +
-				((expected_accumulated_reward_per_share * (10 * PRICE) - expected_reward_debt) /
-					2);
+				((expected_accumulated_reward_per_share * 10 - expected_reward_debt) / 2);
 			assert_eq!(Balances::free_balance(1), expected_balance);
 			assert_eq!(
 				Tellor::accumulated_reward_per_share(),
 				expected_accumulated_reward_per_share
 			);
-			let expected_reward_debt = expected_accumulated_reward_per_share * (10 * PRICE);
+			let expected_reward_debt = expected_accumulated_reward_per_share * 10;
 			assert_eq!(Tellor::total_reward_debt(), expected_reward_debt);
 			let staker_info = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_info.staked_balance, trb(10)); // staked balance

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,8 +44,7 @@ pub(crate) type QueryDataOf<T> = BoundedVec<u8, <T as Config>::MaxQueryDataLengt
 pub type QueryId = H256;
 pub(crate) type ReportOf<T> =
 	oracle::Report<AccountIdOf<T>, BlockNumberOf<T>, ValueOf<T>, <T as Config>::MaxTimestamps>;
-pub(crate) type StakeInfoOf<T> =
-	oracle::StakeInfo<BalanceOf<T>, <T as Config>::MaxQueriesPerReporter>;
+pub(crate) type StakeInfoOf<T> = oracle::StakeInfo<<T as Config>::MaxQueriesPerReporter>;
 pub type Timestamp = u64;
 pub(crate) type TipOf<T> = autopay::Tip<BalanceOf<T>>;
 pub(crate) type ValueOf<T> = BoundedVec<u8, <T as Config>::MaxValueLength>;
@@ -132,7 +131,7 @@ pub(crate) mod oracle {
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(MaxQueries))]
-	pub struct StakeInfo<Balance, MaxQueries: Get<u32>> {
+	pub struct StakeInfo<MaxQueries: Get<u32>> {
 		/// The address on the staking chain.
 		pub(crate) address: Address,
 		/// Stake or withdrawal request start date.
@@ -142,7 +141,7 @@ pub(crate) mod oracle {
 		/// Amount locked for withdrawal.
 		pub(crate) locked_balance: Amount,
 		/// Used for staking reward calculation.
-		pub(crate) reward_debt: Balance,
+		pub(crate) reward_debt: Amount,
 		/// Timestamp of reporter's last reported value.
 		pub(crate) reporter_last_timestamp: Timestamp,
 		/// Total number of reports submitted by reporter.
@@ -157,14 +156,14 @@ pub(crate) mod oracle {
 		pub(crate) reports_submitted_by_query_id: BoundedBTreeMap<QueryId, u128, MaxQueries>,
 	}
 
-	impl<Balance: Default + Zero, MaxQueries: Get<u32>> StakeInfo<Balance, MaxQueries> {
+	impl<MaxQueries: Get<u32>> StakeInfo<MaxQueries> {
 		pub(crate) fn new(address: Address) -> Self {
 			Self {
 				address,
 				start_date: Zero::zero(),
 				staked_balance: Amount::zero(),
 				locked_balance: Amount::zero(),
-				reward_debt: Zero::zero(),
+				reward_debt: Amount::zero(),
 				reporter_last_timestamp: Zero::zero(),
 				reports_submitted: 0,
 				start_vote_count: 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,7 +44,8 @@ pub(crate) type QueryDataOf<T> = BoundedVec<u8, <T as Config>::MaxQueryDataLengt
 pub type QueryId = H256;
 pub(crate) type ReportOf<T> =
 	oracle::Report<AccountIdOf<T>, BlockNumberOf<T>, ValueOf<T>, <T as Config>::MaxTimestamps>;
-pub(crate) type StakeInfoOf<T> = oracle::StakeInfo<<T as Config>::MaxQueriesPerReporter>;
+pub(crate) type StakeInfoOf<T> =
+	oracle::StakeInfo<BalanceOf<T>, <T as Config>::MaxQueriesPerReporter>;
 pub type Timestamp = u64;
 pub(crate) type TipOf<T> = autopay::Tip<BalanceOf<T>>;
 pub(crate) type ValueOf<T> = BoundedVec<u8, <T as Config>::MaxValueLength>;
@@ -131,7 +132,7 @@ pub(crate) mod oracle {
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(MaxQueries))]
-	pub struct StakeInfo<MaxQueries: Get<u32>> {
+	pub struct StakeInfo<Balance, MaxQueries: Get<u32>> {
 		/// The address on the staking chain.
 		pub(crate) address: Address,
 		/// Stake or withdrawal request start date.
@@ -141,7 +142,7 @@ pub(crate) mod oracle {
 		/// Amount locked for withdrawal.
 		pub(crate) locked_balance: Amount,
 		/// Used for staking reward calculation.
-		pub(crate) reward_debt: Amount,
+		pub(crate) reward_debt: Balance,
 		/// Timestamp of reporter's last reported value.
 		pub(crate) reporter_last_timestamp: Timestamp,
 		/// Total number of reports submitted by reporter.
@@ -156,14 +157,14 @@ pub(crate) mod oracle {
 		pub(crate) reports_submitted_by_query_id: BoundedBTreeMap<QueryId, u128, MaxQueries>,
 	}
 
-	impl<MaxQueries: Get<u32>> StakeInfo<MaxQueries> {
+	impl<Balance: Zero, MaxQueries: Get<u32>> StakeInfo<Balance, MaxQueries> {
 		pub(crate) fn new(address: Address) -> Self {
 			Self {
 				address,
 				start_date: Zero::zero(),
 				staked_balance: Amount::zero(),
 				locked_balance: Amount::zero(),
-				reward_debt: Amount::zero(),
+				reward_debt: Zero::zero(),
 				reporter_last_timestamp: Zero::zero(),
 				reports_submitted: 0,
 				start_vote_count: 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,7 +29,7 @@ pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 /// Address of a reporter on controller chain.
 pub type Address = H160;
 /// TRB stake amount as reported from controller chain.
-pub type Amount = U256;
+pub type Tributes = U256;
 /// Local currency used for onetime tips, funding feeds, accumulated rewards and dispute fees.
 pub(crate) type BalanceOf<T> = <T as Config>::Balance;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
@@ -139,9 +139,9 @@ pub(crate) mod oracle {
 		/// Stake or withdrawal request start date.
 		pub(crate) start_date: Timestamp,
 		/// Staked token balance
-		pub(crate) staked_balance: Amount,
+		pub(crate) staked_balance: Tributes,
 		/// Amount locked for withdrawal.
-		pub(crate) locked_balance: Amount,
+		pub(crate) locked_balance: Tributes,
 		/// Used for staking reward calculation.
 		pub(crate) reward_debt: Balance,
 		/// Timestamp of reporter's last reported value.
@@ -191,7 +191,7 @@ pub(crate) mod governance {
 		/// Reporter who submitted the disputed value.
 		pub(crate) disputed_reporter: AccountId,
 		/// Amount slashed from reporter.
-		pub(crate) slashed_amount: Amount,
+		pub(crate) slashed_amount: Tributes,
 	}
 
 	#[derive(

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,8 @@
 use super::Config;
 use frame_support::pallet_prelude::*;
 pub(crate) use governance::Tally;
-use sp_core::{bounded::BoundedBTreeMap, H160, H256, U256};
+pub(crate) use sp_core::U256;
+use sp_core::{bounded::BoundedBTreeMap, H160, H256};
 pub(crate) use sp_runtime::traits::Keccak256;
 use sp_runtime::{
 	traits::{Convert, Zero},
@@ -162,8 +163,8 @@ pub(crate) mod oracle {
 			Self {
 				address,
 				start_date: Zero::zero(),
-				staked_balance: Amount::zero(),
-				locked_balance: Amount::zero(),
+				staked_balance: U256::zero(),
+				locked_balance: U256::zero(),
 				reward_debt: Zero::zero(),
 				reporter_last_timestamp: Zero::zero(),
 				reports_submitted: 0,
@@ -250,8 +251,8 @@ pub struct Configuration {
 }
 
 pub(super) struct U256ToBalance<T>(PhantomData<T>);
-impl<T: Config> Convert<Amount, BalanceOf<T>> for U256ToBalance<T> {
-	fn convert(a: Amount) -> BalanceOf<T> {
+impl<T: Config> Convert<U256, BalanceOf<T>> for U256ToBalance<T> {
+	fn convert(a: U256) -> BalanceOf<T> {
 		a.saturated_into::<u128>().saturated_into()
 	}
 }


### PR DESCRIPTION
Ports staking rewards functionality from `tellorFlex`, where staking rewards are accumulated/paid using the (native) token configured by the parachain and based on ratio of staked TRB amount. All fees/rewards therefore use the `BalanceOf<T>` type, versus any stake amount from the controller chain which uses the `Tributes` (`U256`) type, attempting to maintain a clear distinction between the two.

The general approach followed throughout is to call the `convert()` function to convert a stake amount (`Tributes`) into a local equivalent amount of tokens (`Balance`) and then follow any existing logic from `tellorFlex` to calculate the applicable rates and rewards.

A summary of changes:
- adds `DECIMALS` constant, set to 18 for TRB decimals
- introduces `Decimals: Get<u8>` config item for determining the number of decimals used for the local token, required to convert between TRB stake amount using 18 decimal places and those used on the parachain. 
  - Set to '12' in mock.rs runtime for tests.
- adds `convert_to_decimals()` function for converting decimals places along with accompanying test.
- adds `unit()` helper function which simply returns one unit of local token (i.e. with corresponding decimals as per the `Decimals: Get<u8>` config item
- updates `convert()` function to use a static price, converting a TRB stake amount into a local token balance before converting decimal places. #43 will provide a dynamic price.
  - static price set to '5' for now until dynamic price available
- `get_dispute_fee()` now returns an `Option<BalanceOf<T>>` as the conversion from a TRB stake amount to a local parachain balance amount will depend on some oracle rate (#17)
- implements `update_rewards()` to update accumulated staking rewards per staked token
- adds remaining implementation of `update_stake_and_pay_rewards()`, converting from stake amounts where applicable before calculating local rewards
- renames `Amount` type alias to `Tributes` to provide more context on the stake amounts