### PR TITLE
refactor: relocate sub-account lookups into helper functions

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -30,7 +30,7 @@ use sp_core::{ConstU32, H256};
 use sp_runtime::{
 	generic::BlockId,
 	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup, Zero},
+	traits::{BlakeTwo256, IdentityLookup},
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 use tellor::{

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,5 +23,3 @@ pub(crate) const WEEKS: Timestamp = 7 * DAYS;
 
 /// Base amount of time before a reporter is able to submit a value again.
 pub(crate) const REPORTING_LOCK: Timestamp = 12 * HOURS;
-
-pub(crate) const DISPUTE_SUB_ACCOUNT_ID: &[u8; 7] = b"dispute";

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -31,7 +31,7 @@ use frame_support::{
 	traits::{PalletInfoAccess, UnixTime},
 };
 use sp_core::{bytes::to_hex, keccak_256, H256};
-use sp_runtime::traits::BadOrigin;
+use sp_runtime::traits::{AccountIdConversion, BadOrigin};
 use std::convert::Into;
 use xcm::{latest::prelude::*, DoubleEncoded};
 
@@ -153,6 +153,14 @@ fn converts_token() {
 }
 
 #[test]
+fn dispute_fees() {
+	assert_eq!(
+		Tellor::dispute_fees(),
+		<Test as crate::Config>::PalletId::get().into_sub_account_truncating(b"dispute")
+	)
+}
+
+#[test]
 fn encodes_spot_price() {
 	assert_eq!(
 		"0xa6f013ee236804827b77696d350e9f0ac3e879328f2a3021d473a0b778ad78ac",
@@ -230,4 +238,20 @@ fn register() {
 			)
 		});
 	});
+}
+
+#[test]
+fn staking_rewards() {
+	assert_eq!(
+		Tellor::staking_rewards(),
+		<Test as crate::Config>::PalletId::get().into_sub_account_truncating(b"staking")
+	)
+}
+
+#[test]
+fn tips() {
+	assert_eq!(
+		Tellor::tips(),
+		<Test as crate::Config>::PalletId::get().into_sub_account_truncating(b"tips")
+	)
 }


### PR DESCRIPTION
Simplifies pallet sub-account usage and naming makes logic much easier to follow.