### PR TITLE
Improve min stake amount

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -132,15 +132,15 @@ impl tellor::Config for Test {
 	type Price = u32;
 	type RegistrationOrigin = frame_system::EnsureRoot<AccountId>;
 	type Registry = ();
+	type StakeAmountCurrencyTarget = ();
 	type Staking = ();
 	type StakingOrigin = EnsureStaking;
 	type StakingTokenPriceQueryId = ();
 	type Time = Time;
 	type Token = Balances;
+	type UpdateStakeAmountInterval = ();
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
-	type StakeAmountCurrencyTarget = ();
-	type UpdateStakeAmountInterval = ();
 }
 pub struct TestSendXcm;
 impl tellor::traits::SendXcm for TestSendXcm {
@@ -703,7 +703,7 @@ mod governance {
 	#[test]
 	fn get_dispute_fee() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(Test.get_dispute_fee(&BLOCKID).unwrap(), None);
+			assert_eq!(Test.get_dispute_fee(&BLOCKID).unwrap(), Some(0));
 		});
 	}
 

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -126,6 +126,7 @@ impl tellor::Config for Test {
 	type MaxTipsPerQuery = ();
 	type MaxValueLength = MaxValueLength;
 	type MaxVotes = ();
+	type MinimumStakeAmount = ();
 	type PalletId = TellorPalletId;
 	type ParachainId = ();
 	type Price = u32;
@@ -133,10 +134,13 @@ impl tellor::Config for Test {
 	type Registry = ();
 	type Staking = ();
 	type StakingOrigin = EnsureStaking;
+	type StakingTokenPriceQueryId = ();
 	type Time = Time;
 	type Token = Balances;
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
+	type StakeAmountCurrencyTarget = ();
+	type UpdateStakeAmountInterval = ();
 }
 pub struct TestSendXcm;
 impl tellor::traits::SendXcm for TestSendXcm {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1283,39 +1283,38 @@ impl<T: Config> Pallet<T> {
 
 	// Updates the stake amount after retrieving the latest token price from oracle.
 	pub(super) fn _update_stake_amount() -> DispatchResult {
-		if let Some((value, _timestamp)) = Self::get_data_before(
+		let Some((value, _)) = Self::get_data_before(
 			T::StakingTokenPriceQueryId::get(),
 			Self::now().saturating_sub(12 * HOURS),
-		) {
-			match T::ValueConverter::convert(value.into_inner()) {
-				None => return Err(Error::<T>::InvalidStakingTokenPrice.into()),
-				Some(staking_token_price) => {
-					let staking_token_price = staking_token_price.into();
-					ensure!(
-						staking_token_price >= 10u128.pow(16).into() &&
-							staking_token_price < 10u128.pow(24).into(),
-						Error::<T>::InvalidStakingTokenPrice
-					);
-					let adjusted_stake_amount = (T::StakeAmountCurrencyTarget::get()
-						.checked_mul(Amount::from(10u128.pow(18)))
-						.ok_or(ArithmeticError::Overflow)?)
-					.checked_div(staking_token_price)
-					.expect("price range checked above; qed");
+		) else {
+			return Err(Error::<T>::InvalidStakingTokenPrice.into());
+		};
+		let Some(staking_token_price) = T::ValueConverter::convert(value.into_inner()) else {
+			return Err(Error::<T>::InvalidStakingTokenPrice.into());
+		};
+		let staking_token_price = staking_token_price.into();
+		ensure!(
+			staking_token_price >= 10u128.pow(16).into() &&
+				staking_token_price < 10u128.pow(24).into(),
+			Error::<T>::InvalidStakingTokenPrice
+		);
+		let adjusted_stake_amount = (T::StakeAmountCurrencyTarget::get()
+			.checked_mul(Amount::from(10u128.pow(18)))
+			.ok_or(ArithmeticError::Overflow)?)
+		.checked_div(staking_token_price)
+		.expect("price range checked above; qed");
 
-					let amount = <StakeAmount<T>>::mutate(|amount| {
-						let minimum_stake_amount = T::MinimumStakeAmount::get().into();
-						if adjusted_stake_amount < minimum_stake_amount {
-							*amount = minimum_stake_amount;
-							minimum_stake_amount
-						} else {
-							*amount = adjusted_stake_amount;
-							adjusted_stake_amount
-						}
-					});
-					Self::deposit_event(Event::NewStakeAmount { amount });
-				},
+		let amount = <StakeAmount<T>>::mutate(|amount| {
+			let minimum_stake_amount = T::MinimumStakeAmount::get().into();
+			if adjusted_stake_amount < minimum_stake_amount {
+				*amount = minimum_stake_amount;
+				minimum_stake_amount
+			} else {
+				*amount = adjusted_stake_amount;
+				adjusted_stake_amount
 			}
-		}
+		});
+		Self::deposit_event(Event::NewStakeAmount { amount });
 		Ok(())
 	}
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -338,7 +338,7 @@ impl<T: Config> Pallet<T> {
 				const PRICE: Option<u128> = Some(5 * UNIT); // spot price query uses 18 decimal places as per data spec
 
 				PRICE
-					.map(|price| U256::from(price))
+					.map(U256::from)
 					// Convert amount into local balance amount based on price
 					.and_then(|price| {
 						a.checked_mul(price).and_then(|a| a.checked_div(U256::from(UNIT)))
@@ -346,7 +346,7 @@ impl<T: Config> Pallet<T> {
 			})
 			// Convert to local number of decimals
 			.and_then(|a| Self::convert(a).ok())
-			.map(|a| U256ToBalance::<T>::convert(a))
+			.map(U256ToBalance::<T>::convert)
 	}
 
 	/// Returns information on a dispute for a given identifier.

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1287,29 +1287,33 @@ impl<T: Config> Pallet<T> {
 			T::StakingTokenPriceQueryId::get(),
 			Self::now().saturating_sub(12 * HOURS),
 		) {
-			if let Some(staking_token_price) = T::ValueConverter::convert(value.into_inner()) {
-				ensure!(
-					staking_token_price >= 10u32.pow(16).into() &&
-						staking_token_price < 10u32.pow(24).into(),
-					Error::<T>::InvalidStakingTokenPrice
-				);
-				let adjusted_stake_amount = (T::StakeAmountCurrencyTarget::get()
-					.checked_mul(Amount::from(10u128.pow(18)))
-					.ok_or(ArithmeticError::Overflow)?)
-				.checked_div(staking_token_price.into())
-				.expect("price range checked above; qed");
+			match T::ValueConverter::convert(value.into_inner()) {
+				None => return Err(Error::<T>::InvalidStakingTokenPrice.into()),
+				Some(staking_token_price) => {
+					let staking_token_price = staking_token_price.into();
+					ensure!(
+						staking_token_price >= 10u128.pow(16).into() &&
+							staking_token_price < 10u128.pow(24).into(),
+						Error::<T>::InvalidStakingTokenPrice
+					);
+					let adjusted_stake_amount = (T::StakeAmountCurrencyTarget::get()
+						.checked_mul(Amount::from(10u128.pow(18)))
+						.ok_or(ArithmeticError::Overflow)?)
+					.checked_div(staking_token_price)
+					.expect("price range checked above; qed");
 
-				let amount = <StakeAmount<T>>::mutate(|amount| {
-					let minimum_stake_amount = T::MinimumStakeAmount::get().into();
-					if adjusted_stake_amount < minimum_stake_amount {
-						*amount = minimum_stake_amount;
-						minimum_stake_amount
-					} else {
-						*amount = adjusted_stake_amount;
-						adjusted_stake_amount
-					}
-				});
-				Self::deposit_event(Event::NewStakeAmount { amount });
+					let amount = <StakeAmount<T>>::mutate(|amount| {
+						let minimum_stake_amount = T::MinimumStakeAmount::get().into();
+						if adjusted_stake_amount < minimum_stake_amount {
+							*amount = minimum_stake_amount;
+							minimum_stake_amount
+						} else {
+							*amount = adjusted_stake_amount;
+							adjusted_stake_amount
+						}
+					});
+					Self::deposit_event(Event::NewStakeAmount { amount });
+				},
 			}
 		}
 		Ok(())

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -23,39 +23,6 @@ use sp_runtime::{
 };
 
 impl<T: Config> Pallet<T> {
-	/// Funds the staking account with staking rewards from the source account.
-	/// # Arguments
-	/// * `source` - The source account.
-	/// * `amount` - The amount of tokens to fund the staking account with.
-	pub(super) fn _add_staking_rewards(
-		source: &AccountIdOf<T>,
-		amount: BalanceOf<T>,
-	) -> DispatchResult {
-		let staking_rewards = Self::staking_rewards();
-		T::Token::transfer(source, &staking_rewards, amount, false)?;
-		Self::update_rewards()?;
-		let staking_rewards_balance = T::Token::balance(&staking_rewards).into();
-		// update reward rate = real staking rewards balance / 30 days
-		let total_stake_amount = Self::convert(<TotalStakeAmount<T>>::get())?;
-		<RewardRate<T>>::set(U256ToBalance::<T>::convert(
-			(staking_rewards_balance
-				.checked_sub(
-					(<AccumulatedRewardPerShare<T>>::get()
-						.into()
-						.checked_mul(total_stake_amount)
-						.ok_or(ArithmeticError::Overflow)?)
-					.checked_div(U256::from(Self::unit()?))
-					.ok_or(ArithmeticError::DivisionByZero)?
-					.checked_sub(<TotalRewardDebt<T>>::get().into())
-					.ok_or(ArithmeticError::Underflow)?,
-				)
-				.ok_or(ArithmeticError::Underflow)?)
-			.checked_div(U256::from(30 * DAYS))
-			.expect("days constant is greater than zero; qed"),
-		));
-		Ok(())
-	}
-
 	pub(super) fn bytes_to_price(value: ValueOf<T>) -> Result<T::Price, DispatchError> {
 		T::ValueConverter::convert(value.into_inner())
 	}
@@ -116,6 +83,183 @@ impl<T: Config> Pallet<T> {
 	/// value and only call this once.
 	pub(super) fn dispute_fees() -> T::AccountId {
 		T::PalletId::get().into_sub_account_truncating(b"dispute")
+	}
+
+	/// Funds the staking account with staking rewards from the source account.
+	/// # Arguments
+	/// * `source` - The source account.
+	/// * `amount` - The amount of tokens to fund the staking account with.
+	pub(super) fn do_add_staking_rewards(
+		source: &AccountIdOf<T>,
+		amount: BalanceOf<T>,
+	) -> DispatchResult {
+		let staking_rewards = Self::staking_rewards();
+		T::Token::transfer(source, &staking_rewards, amount, false)?;
+		Self::update_rewards()?;
+		let staking_rewards_balance = T::Token::balance(&staking_rewards).into();
+		// update reward rate = real staking rewards balance / 30 days
+		let total_stake_amount = Self::convert(<TotalStakeAmount<T>>::get())?;
+		<RewardRate<T>>::set(U256ToBalance::<T>::convert(
+			(staking_rewards_balance
+				.checked_sub(
+					(<AccumulatedRewardPerShare<T>>::get()
+						.into()
+						.checked_mul(total_stake_amount)
+						.ok_or(ArithmeticError::Overflow)?)
+					.checked_div(U256::from(Self::unit()?))
+					.ok_or(ArithmeticError::DivisionByZero)?
+					.checked_sub(<TotalRewardDebt<T>>::get().into())
+					.ok_or(ArithmeticError::Underflow)?,
+				)
+				.ok_or(ArithmeticError::Underflow)?)
+			.checked_div(U256::from(30 * DAYS))
+			.expect("days constant is greater than zero; qed"),
+		));
+		Ok(())
+	}
+
+	/// Allows data feed account to be filled with tokens.
+	/// # Arguments
+	/// * `feed_funder`: Account funding the feed.
+	/// * `feed_id`: Unique feed identifier.
+	/// * `query_id`: Identifier of reported data type associated with feed.
+	/// * `amount`: Quantity of tokens to fund feed.
+	pub(super) fn do_fund_feed(
+		feed_funder: AccountIdOf<T>,
+		feed_id: FeedId,
+		query_id: QueryId,
+		amount: BalanceOf<T>,
+	) -> DispatchResult {
+		let Some(mut feed) = <DataFeeds<T>>::get(query_id, feed_id) else {
+			return Err(Error::<T>::InvalidFeed.into());
+		};
+
+		ensure!(amount > Zero::zero(), Error::<T>::InvalidAmount);
+		feed.details.balance.saturating_accrue(amount);
+		T::Token::transfer(&feed_funder, &Self::tips(), amount, true)?;
+		// Add to array of feeds with funding
+		if feed.details.feeds_with_funding_index == 0 && feed.details.balance > Zero::zero() {
+			let index = <FeedsWithFunding<T>>::try_mutate(
+				|feeds_with_funding| -> Result<usize, DispatchError> {
+					feeds_with_funding.try_push(feed_id).map_err(|_| Error::<T>::MaxFeedsFunded)?;
+					Ok(feeds_with_funding.len())
+				},
+			)?;
+			feed.details.feeds_with_funding_index = index.saturated_into::<u32>();
+		}
+		let feed_details = feed.details.clone();
+		<DataFeeds<T>>::insert(query_id, feed_id, feed);
+		<UserTipsTotal<T>>::mutate(&feed_funder, |total| total.saturating_accrue(amount));
+		Self::deposit_event(Event::DataFeedFunded {
+			feed_id,
+			query_id,
+			amount,
+			feed_funder,
+			feed_details,
+		});
+		Ok(())
+	}
+
+	/// Read potential reward for an oracle submission.
+	/// # Arguments
+	/// * `feed_id` - Data feed unique identifier.
+	/// * `query_id` - Identifier of reported data.
+	/// * `timestamp` - Timestamp of oracle submission.
+	/// # Returns
+	/// Potential reward for an oracle submission.
+	pub(super) fn do_get_reward_amount(
+		feed_id: FeedId,
+		query_id: QueryId,
+		timestamp: Timestamp,
+	) -> Result<BalanceOf<T>, DispatchError> {
+		ensure!(Self::now().saturating_sub(timestamp) < 4 * WEEKS, Error::<T>::ClaimPeriodExpired);
+
+		let feed = <DataFeeds<T>>::get(query_id, feed_id).ok_or(Error::<T>::InvalidFeed)?;
+		ensure!(
+			!feed.reward_claimed.get(&timestamp).unwrap_or(&false),
+			Error::<T>::TipAlreadyClaimed
+		);
+		let n = (timestamp.saturating_sub(feed.details.start_time))
+			.checked_div(feed.details.interval)
+			.ok_or(ArithmeticError::DivisionByZero)?; // finds closest interval n to timestamp
+		let c = feed.details.start_time.saturating_add(feed.details.interval.saturating_mul(n)); // finds start timestamp c of interval n
+		let value_retrieved = Self::retrieve_data(query_id, timestamp);
+		ensure!(value_retrieved.as_ref().map_or(0, |v| v.len()) != 0, Error::<T>::InvalidTimestamp);
+		let (value_retrieved_before, timestamp_before) =
+			Self::get_data_before(query_id, timestamp).unwrap_or_default();
+		let mut price_change = 0; // price change from last value to current value
+		if feed.details.price_threshold != 0 {
+			let v1 =
+				Self::bytes_to_price(value_retrieved.expect("value retrieved checked above; qed"))?;
+			let v2 = Self::bytes_to_price(value_retrieved_before)?;
+			if v2 == Zero::zero() {
+				price_change = 10_000;
+			} else if v1 >= v2 {
+				price_change = (T::Price::from(10_000u16).saturating_mul(v1.saturating_sub(v2)))
+					.checked_div(&v2)
+					.expect("v2 checked against zero above; qed")
+					.saturated_into();
+			} else {
+				price_change = (T::Price::from(10_000u16).saturating_mul(v2.saturating_sub(v1)))
+					.checked_div(&v2)
+					.expect("v2 checked against zero above; qed")
+					.saturated_into();
+			}
+		}
+		let mut reward_amount = feed.details.reward;
+		let time_diff = timestamp.saturating_sub(c); // time difference between report timestamp and start of interval
+
+		// ensure either report is first within a valid window, or price change threshold is met
+		if time_diff < feed.details.window && timestamp_before < c {
+			// add time based rewards if applicable
+			reward_amount.saturating_accrue(
+				feed.details.reward_increase_per_second.saturating_mul(time_diff.into()),
+			);
+		} else {
+			ensure!(price_change > feed.details.price_threshold, Error::<T>::PriceThresholdNotMet);
+		}
+
+		if feed.details.balance < reward_amount {
+			reward_amount = feed.details.balance;
+		}
+		Ok(reward_amount)
+	}
+
+	// Updates the stake amount after retrieving the latest token price from oracle.
+	pub(super) fn do_update_stake_amount() -> DispatchResult {
+		let Some((value, _)) = Self::get_data_before(
+			T::StakingTokenPriceQueryId::get(),
+			Self::now().saturating_sub(12 * HOURS),
+		) else {
+			return Err(Error::<T>::InvalidStakingTokenPrice.into());
+		};
+		let Ok(staking_token_price) = T::ValueConverter::convert(value.into_inner()) else {
+			return Err(Error::<T>::InvalidStakingTokenPrice.into());
+		};
+		let staking_token_price = staking_token_price.into();
+		ensure!(
+			staking_token_price >= 10u128.pow(16).into() &&
+				staking_token_price < 10u128.pow(24).into(),
+			Error::<T>::InvalidStakingTokenPrice
+		);
+		let adjusted_stake_amount = (Tributes::from(T::StakeAmountCurrencyTarget::get())
+			.checked_mul(Tributes::from(10u128.pow(18)))
+			.ok_or(ArithmeticError::Overflow)?)
+		.checked_div(staking_token_price)
+		.expect("price range checked above; qed");
+
+		let amount = <StakeAmount<T>>::mutate(|amount| {
+			let minimum_stake_amount = T::MinimumStakeAmount::get().into();
+			if adjusted_stake_amount < minimum_stake_amount {
+				*amount = minimum_stake_amount;
+				minimum_stake_amount
+			} else {
+				*amount = adjusted_stake_amount;
+				adjusted_stake_amount
+			}
+		});
+		Self::deposit_event(Event::NewStakeAmount { amount });
+		Ok(())
 	}
 
 	/// Executes the vote and transfers corresponding dispute fees to initiator/reporter.
@@ -182,42 +326,6 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	pub(super) fn _fund_feed(
-		feed_funder: AccountIdOf<T>,
-		feed_id: FeedId,
-		query_id: QueryId,
-		amount: BalanceOf<T>,
-	) -> DispatchResult {
-		let Some(mut feed) = <DataFeeds<T>>::get(query_id, feed_id) else {
-			return Err(Error::<T>::InvalidFeed.into());
-		};
-
-		ensure!(amount > Zero::zero(), Error::<T>::InvalidAmount);
-		feed.details.balance.saturating_accrue(amount);
-		T::Token::transfer(&feed_funder, &Self::tips(), amount, true)?;
-		// Add to array of feeds with funding
-		if feed.details.feeds_with_funding_index == 0 && feed.details.balance > Zero::zero() {
-			let index = <FeedsWithFunding<T>>::try_mutate(
-				|feeds_with_funding| -> Result<usize, DispatchError> {
-					feeds_with_funding.try_push(feed_id).map_err(|_| Error::<T>::MaxFeedsFunded)?;
-					Ok(feeds_with_funding.len())
-				},
-			)?;
-			feed.details.feeds_with_funding_index = index.saturated_into::<u32>();
-		}
-		let feed_details = feed.details.clone();
-		<DataFeeds<T>>::insert(query_id, feed_id, feed);
-		<UserTipsTotal<T>>::mutate(&feed_funder, |total| total.saturating_accrue(amount));
-		Self::deposit_event(Event::DataFeedFunded {
-			feed_id,
-			query_id,
-			amount,
-			feed_funder,
-			feed_details,
-		});
-		Ok(())
-	}
-
 	/// Returns the block number at a given timestamp.
 	/// # Arguments
 	/// * `query_id` - The identifier of the specific data feed.
@@ -252,7 +360,8 @@ impl<T: Config> Pallet<T> {
 		if <Tips<T>>::get(query_id).map_or(0, |t| t.len()) == 0 {
 			return Zero::zero()
 		}
-		let timestamp_retrieved = Self::_get_current_value(query_id).map_or(0, |v| v.1);
+		let timestamp_retrieved =
+			Self::get_current_value_and_timestamp(query_id).map_or(0, |v| v.1);
 		match <Tips<T>>::get(query_id) {
 			Some(tips) => match tips.last() {
 				Some(last_tip) if timestamp_retrieved < last_tip.timestamp => last_tip.amount,
@@ -262,12 +371,25 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
+	/// Returns the current value of a data feed given a specific identifier.
+	/// # Arguments
+	/// * `query_id` - The identifier of the specific data feed.
+	/// # Returns
+	/// The latest submitted value for the given identifier.
+	pub fn get_current_value(query_id: QueryId) -> Option<ValueOf<T>> {
+		// todo: implement properly
+		<Reports<T>>::get(query_id)
+			.and_then(|r| r.value_by_timestamp.last_key_value().map(|kv| kv.1.clone()))
+	}
+
 	/// Allows the user to get the latest value for the query identifier specified.
 	/// # Arguments
 	/// * `query_id` - Identifier to look up the value for
 	/// # Returns
 	/// The value retrieved, along with its timestamp, if found.
-	pub(super) fn _get_current_value(query_id: QueryId) -> Option<(ValueOf<T>, Timestamp)> {
+	pub(super) fn get_current_value_and_timestamp(
+		query_id: QueryId,
+	) -> Option<(ValueOf<T>, Timestamp)> {
 		let mut count = Self::get_new_value_count_by_query_id(query_id);
 		if count == 0 {
 			return None
@@ -284,17 +406,6 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 		None
-	}
-
-	/// Returns the current value of a data feed given a specific identifier.
-	/// # Arguments
-	/// * `query_id` - The identifier of the specific data feed.
-	/// # Returns
-	/// The latest submitted value for the given identifier.
-	pub fn get_current_value(query_id: QueryId) -> Option<ValueOf<T>> {
-		// todo: implement properly
-		<Reports<T>>::get(query_id)
-			.and_then(|r| r.value_by_timestamp.last_key_value().map(|kv| kv.1.clone()))
 	}
 
 	/// Retrieves the latest value for the query identifier before the specified timestamp.
@@ -731,64 +842,6 @@ impl<T: Config> Pallet<T> {
 			.unwrap_or_default()
 	}
 
-	pub(super) fn _get_reward_amount(
-		feed_id: FeedId,
-		query_id: QueryId,
-		timestamp: Timestamp,
-	) -> Result<BalanceOf<T>, DispatchError> {
-		ensure!(Self::now().saturating_sub(timestamp) < 4 * WEEKS, Error::<T>::ClaimPeriodExpired);
-
-		let feed = <DataFeeds<T>>::get(query_id, feed_id).ok_or(Error::<T>::InvalidFeed)?;
-		ensure!(
-			!feed.reward_claimed.get(&timestamp).unwrap_or(&false),
-			Error::<T>::TipAlreadyClaimed
-		);
-		let n = (timestamp.saturating_sub(feed.details.start_time))
-			.checked_div(feed.details.interval)
-			.ok_or(ArithmeticError::DivisionByZero)?; // finds closest interval n to timestamp
-		let c = feed.details.start_time.saturating_add(feed.details.interval.saturating_mul(n)); // finds start timestamp c of interval n
-		let value_retrieved = Self::retrieve_data(query_id, timestamp);
-		ensure!(value_retrieved.as_ref().map_or(0, |v| v.len()) != 0, Error::<T>::InvalidTimestamp);
-		let (value_retrieved_before, timestamp_before) =
-			Self::get_data_before(query_id, timestamp).unwrap_or_default();
-		let mut price_change = 0; // price change from last value to current value
-		if feed.details.price_threshold != 0 {
-			let v1 =
-				Self::bytes_to_price(value_retrieved.expect("value retrieved checked above; qed"))?;
-			let v2 = Self::bytes_to_price(value_retrieved_before)?;
-			if v2 == Zero::zero() {
-				price_change = 10_000;
-			} else if v1 >= v2 {
-				price_change = (T::Price::from(10_000u16).saturating_mul(v1.saturating_sub(v2)))
-					.checked_div(&v2)
-					.expect("v2 checked against zero above; qed")
-					.saturated_into();
-			} else {
-				price_change = (T::Price::from(10_000u16).saturating_mul(v2.saturating_sub(v1)))
-					.checked_div(&v2)
-					.expect("v2 checked against zero above; qed")
-					.saturated_into();
-			}
-		}
-		let mut reward_amount = feed.details.reward;
-		let time_diff = timestamp.saturating_sub(c); // time difference between report timestamp and start of interval
-
-		// ensure either report is first within a valid window, or price change threshold is met
-		if time_diff < feed.details.window && timestamp_before < c {
-			// add time based rewards if applicable
-			reward_amount.saturating_accrue(
-				feed.details.reward_increase_per_second.saturating_mul(time_diff.into()),
-			);
-		} else {
-			ensure!(price_change > feed.details.price_threshold, Error::<T>::PriceThresholdNotMet);
-		}
-
-		if feed.details.balance < reward_amount {
-			reward_amount = feed.details.balance;
-		}
-		Ok(reward_amount)
-	}
-
 	/// Read potential reward for a set of oracle submissions.
 	/// # Arguments
 	/// * `feed_id` - Data feed unique identifier.
@@ -807,7 +860,7 @@ impl<T: Config> Pallet<T> {
 		let mut cumulative_reward = <BalanceOf<T>>::zero();
 		for timestamp in timestamps {
 			cumulative_reward.saturating_accrue(
-				Self::_get_reward_amount(feed_id, query_id, timestamp).unwrap_or_default(),
+				Self::do_get_reward_amount(feed_id, query_id, timestamp).unwrap_or_default(),
 			)
 		}
 		if cumulative_reward > feed.details.balance {
@@ -1278,43 +1331,6 @@ impl<T: Config> Pallet<T> {
 			}
 			Ok(())
 		})?;
-		Ok(())
-	}
-
-	// Updates the stake amount after retrieving the latest token price from oracle.
-	pub(super) fn _update_stake_amount() -> DispatchResult {
-		let Some((value, _)) = Self::get_data_before(
-			T::StakingTokenPriceQueryId::get(),
-			Self::now().saturating_sub(12 * HOURS),
-		) else {
-			return Err(Error::<T>::InvalidStakingTokenPrice.into());
-		};
-		let Ok(staking_token_price) = T::ValueConverter::convert(value.into_inner()) else {
-			return Err(Error::<T>::InvalidStakingTokenPrice.into());
-		};
-		let staking_token_price = staking_token_price.into();
-		ensure!(
-			staking_token_price >= 10u128.pow(16).into() &&
-				staking_token_price < 10u128.pow(24).into(),
-			Error::<T>::InvalidStakingTokenPrice
-		);
-		let adjusted_stake_amount = (Tributes::from(T::StakeAmountCurrencyTarget::get())
-			.checked_mul(Tributes::from(10u128.pow(18)))
-			.ok_or(ArithmeticError::Overflow)?)
-		.checked_div(staking_token_price)
-		.expect("price range checked above; qed");
-
-		let amount = <StakeAmount<T>>::mutate(|amount| {
-			let minimum_stake_amount = T::MinimumStakeAmount::get().into();
-			if adjusted_stake_amount < minimum_stake_amount {
-				*amount = minimum_stake_amount;
-				minimum_stake_amount
-			} else {
-				*amount = adjusted_stake_amount;
-				adjusted_stake_amount
-			}
-		});
-		Self::deposit_event(Event::NewStakeAmount { amount });
 		Ok(())
 	}
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1280,6 +1280,32 @@ impl<T: Config> Pallet<T> {
 		})?;
 		Ok(())
 	}
+
+	// Updates the stake amount after retrieving the latest token price from oracle.
+	pub(super) fn _update_stake_amount(query_id: QueryId) -> DispatchResult {
+		//todo
+		// get staking token price
+		// (bool _valFound, bytes memory _val, ) = getDataBefore(
+		// 	stakingTokenPriceQueryId,
+		// 	block.timestamp - 12 hours
+		// );
+		// if (_valFound) {
+		// 	uint256 _stakingTokenPrice = abi.decode(_val, (uint256));
+		// 	require(
+		// 		_stakingTokenPrice >= 0.01 ether && _stakingTokenPrice < 1000000 ether,
+		// 		"invalid staking token price"
+		// 	);
+		// 	uint256 _adjustedStakeAmount = (stakeAmountDollarTarget * 1e18) / _stakingTokenPrice;
+		// 	if(_adjustedStakeAmount < minimumStakeAmount) {
+		// 		stakeAmount = minimumStakeAmount;
+		// 	} else {
+		// 		stakeAmount = _adjustedStakeAmount;
+		// 	}
+		// 	emit NewStakeAmount(stakeAmount);
+		// }
+
+		Ok(())
+	}
 }
 
 impl<T: Config> UsingTellor<AccountIdOf<T>, PriceOf<T>> for Pallet<T> {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -331,7 +331,7 @@ impl<T: Config> Pallet<T> {
 	/// The latest dispute fee.
 	pub fn get_dispute_fee() -> Option<BalanceOf<T>> {
 		<StakeAmount<T>>::get()
-			.and_then(|a| a.checked_div(U256::from(10)))
+			.checked_div(U256::from(10))
 			.and_then(|a| {
 				// todo: use rate from oracle
 				const UNIT: u128 = 10u128.pow(DECIMALS);
@@ -1289,7 +1289,7 @@ impl<T: Config> Pallet<T> {
 		) else {
 			return Err(Error::<T>::InvalidStakingTokenPrice.into());
 		};
-		let Some(staking_token_price) = T::ValueConverter::convert(value.into_inner()) else {
+		let Ok(staking_token_price) = T::ValueConverter::convert(value.into_inner()) else {
 			return Err(Error::<T>::InvalidStakingTokenPrice.into());
 		};
 		let staking_token_price = staking_token_price.into();
@@ -1298,8 +1298,8 @@ impl<T: Config> Pallet<T> {
 				staking_token_price < 10u128.pow(24).into(),
 			Error::<T>::InvalidStakingTokenPrice
 		);
-		let adjusted_stake_amount = (T::StakeAmountCurrencyTarget::get()
-			.checked_mul(Amount::from(10u128.pow(18)))
+		let adjusted_stake_amount = (Tributes::from(T::StakeAmountCurrencyTarget::get())
+			.checked_mul(Tributes::from(10u128.pow(18)))
 			.ok_or(ArithmeticError::Overflow)?)
 		.checked_div(staking_token_price)
 		.expect("price range checked above; qed");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,7 +538,7 @@ pub mod pallet {
 				let timestamp = Self::now();
 				if timestamp >=
 					<LastStakeAmountUpdate<T>>::get() + update_interval.max(MIN_INTERVAL) &&
-					Pallet::<T>::_update_stake_amount().is_ok()
+					Pallet::<T>::do_update_stake_amount().is_ok()
 				{
 					<LastStakeAmountUpdate<T>>::set(timestamp)
 				}
@@ -637,7 +637,7 @@ pub mod pallet {
 				cumulative_reward - fee,
 				false,
 			)?;
-			Self::_add_staking_rewards(tips, fee)?;
+			Self::do_add_staking_rewards(tips, fee)?;
 			if Self::get_current_tip(query_id) == Zero::zero() {
 				let index = <QueryIdsWithFundingIndex<T>>::get(query_id).unwrap_or_default();
 				if index != 0 {
@@ -704,7 +704,7 @@ pub mod pallet {
 					Error::<T>::InvalidClaimer
 				);
 				cumulative_reward
-					.saturating_accrue(Self::_get_reward_amount(feed_id, query_id, *timestamp)?);
+					.saturating_accrue(Self::do_get_reward_amount(feed_id, query_id, *timestamp)?);
 
 				if cumulative_reward >= balance {
 					ensure!(
@@ -765,7 +765,7 @@ pub mod pallet {
 				cumulative_reward - fee,
 				false,
 			)?;
-			Self::_add_staking_rewards(tips, fee)?;
+			Self::do_add_staking_rewards(tips, fee)?;
 			Self::deposit_event(Event::TipClaimed {
 				feed_id,
 				query_id,
@@ -788,7 +788,7 @@ pub mod pallet {
 			amount: BalanceOf<T>,
 		) -> DispatchResult {
 			let feed_funder = ensure_signed(origin)?;
-			Self::_fund_feed(feed_funder, feed_id, query_id, amount)
+			Self::do_fund_feed(feed_funder, feed_id, query_id, amount)
 		}
 
 		/// Initializes data feed parameters.
@@ -872,7 +872,7 @@ pub mod pallet {
 				feed_creator: feed_creator.clone(),
 			});
 			if amount > Zero::zero() {
-				Self::_fund_feed(feed_creator, feed_id, query_id, amount)?;
+				Self::do_fund_feed(feed_creator, feed_id, query_id, amount)?;
 			}
 			Ok(())
 		}
@@ -909,7 +909,7 @@ pub mod pallet {
 					},
 					Some(tips) => {
 						let timestamp_retrieved =
-							Self::_get_current_value(query_id).map_or(0, |v| v.1);
+							Self::get_current_value_and_timestamp(query_id).map_or(0, |v| v.1);
 						match tips.last_mut() {
 							Some(last_tip) if timestamp_retrieved < last_tip.timestamp => {
 								last_tip.timestamp = Self::now().saturating_add(1u8.into());
@@ -955,7 +955,7 @@ pub mod pallet {
 		#[pallet::call_index(6)]
 		pub fn add_staking_rewards(origin: OriginFor<T>, amount: BalanceOf<T>) -> DispatchResult {
 			let funder = ensure_signed(origin)?;
-			Self::_add_staking_rewards(&funder, amount)
+			Self::do_add_staking_rewards(&funder, amount)
 		}
 
 		/// Allows a reporter to submit a value to the oracle.
@@ -1090,7 +1090,7 @@ pub mod pallet {
 		#[pallet::call_index(8)]
 		pub fn update_stake_amount(origin: OriginFor<T>) -> DispatchResult {
 			ensure_signed(origin)?;
-			Self::_update_stake_amount()
+			Self::do_update_stake_amount()
 		}
 
 		/// Initialises a dispute/vote in the system.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type StakeAmountCurrencyTarget: Get<U256>;
 		#[pallet::constant]
-		type UpdateStakeInterval: Get<Self::BlockNumber>;
+		type UpdateStakeAmountInterval: Get<Self::BlockNumber>;
 	}
 
 	// AutoPay
@@ -530,7 +530,7 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			// Update stake amount
-			if n >= <StakeAmountBlockNumber<T>>::get() + T::UpdateStakeInterval::get() {
+			if n >= <StakeAmountBlockNumber<T>>::get() + T::UpdateStakeAmountInterval::get() {
 				match Pallet::<T>::_update_stake_amount() {
 					Ok(_) => <StakeAmountBlockNumber<T>>::set(n),
 					Err(_e) => todo!("log error"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,7 @@ pub mod pallet {
 	pub(super) type AccumulatedRewardPerShare<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 	/// Mapping of query identifiers to a report.
 	#[pallet::storage]
+	#[pallet::getter(fn last_stake_amount_update)]
 	pub(super) type LastStakeAmountUpdate<T> = StorageValue<_, Timestamp, ValueQuery>;
 	#[pallet::storage]
 	pub(super) type Reports<T> = StorageMap<_, Blake2_128Concat, QueryId, ReportOf<T>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,11 +537,10 @@ pub mod pallet {
 			if update_interval > Zero::zero() {
 				let timestamp = Self::now();
 				if timestamp >=
-					<LastStakeAmountUpdate<T>>::get() + update_interval.max(MIN_INTERVAL.into())
+					<LastStakeAmountUpdate<T>>::get() + update_interval.max(MIN_INTERVAL) &&
+					Pallet::<T>::_update_stake_amount().is_ok()
 				{
-					if let Ok(_) = Pallet::<T>::_update_stake_amount() {
-						<LastStakeAmountUpdate<T>>::set(timestamp)
-					}
+					<LastStakeAmountUpdate<T>>::set(timestamp)
 				}
 			}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,10 +530,10 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			// Update stake amount
-			if n >= <StakeAmountBlockNumber<T>>::get() + T::UpdateStakeAmountInterval::get() {
-				match Pallet::<T>::_update_stake_amount() {
-					Ok(_) => <StakeAmountBlockNumber<T>>::set(n),
-					Err(_e) => todo!("log error"),
+			let interval = T::UpdateStakeAmountInterval::get();
+			if interval > 0 && n >= <StakeAmountBlockNumber<T>>::get() + interval {
+				if let Ok(_) = Pallet::<T>::_update_stake_amount() {
+					<StakeAmountBlockNumber<T>>::set(n)
 				}
 			}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,10 @@ pub mod pallet {
 		/// Origin that handles staking.
 		type StakingOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 
+		/// Staking token 'SpotPrice' query identifier, used for updating stake amount.
+		#[pallet::constant]
+		type StakingTokenPriceQueryId: Get<QueryId>;
+
 		/// The on-chain time provider.
 		type Time: UnixTime;
 
@@ -192,8 +196,6 @@ pub mod pallet {
 
 		#[pallet::constant]
 		type StakeAmountCurrencyTarget: Get<U256>;
-		#[pallet::constant]
-		type StakingTokenPriceQueryId: Get<QueryId>;
 		#[pallet::constant]
 		type UpdateStakeInterval: Get<Self::BlockNumber>;
 	}

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -147,7 +147,7 @@ impl tellor::Config for Test {
 	type Price = u128;
 	type RegistrationOrigin = system::EnsureRoot<AccountId>;
 	type Registry = TellorRegistry;
-	type StakeAmountCurrencyTarget = ConstU128<1_500>;
+	type StakeAmountCurrencyTarget = ConstU128<{ 500 * 10u128.pow(18) }>;
 	type Staking = TellorStaking;
 	type StakingOrigin = EnsureStaking;
 	type StakingTokenPriceQueryId = StakingTokenPriceQueryId;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -114,6 +114,7 @@ static GOVERNANCE: Lazy<[u8; 20]> = Lazy::new(|| Address::random().into());
 static STAKING: Lazy<[u8; 20]> = Lazy::new(|| Address::random().into());
 
 parameter_types! {
+	pub const MinimumStakeAmount: u128 = 100 * 10u128.pow(18);
 	pub const TellorPalletId: PalletId = PalletId(*b"py/tellr");
 	pub const ParachainId: u32 = PARA_ID;
 	pub TellorRegistry: ContractLocation = (EVM_PARA_ID, *REGISTRY).into();
@@ -139,6 +140,7 @@ impl tellor::Config for Test {
 	type MaxTipsPerQuery = ConstU32<10>;
 	type MaxValueLength = ConstU32<128>; // Chain may want to store any raw bytes, so ValueConverter needs to handle conversion to price for threshold checks
 	type MaxVotes = ConstU32<10>;
+	type MinimumStakeAmount = MinimumStakeAmount;
 	type PalletId = TellorPalletId;
 	type ParachainId = ParachainId;
 	type Price = u128;
@@ -150,7 +152,6 @@ impl tellor::Config for Test {
 	type Token = Balances;
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
-	type MinimumStakeAmount = ();
 	type StakeAmountCurrencyTarget = ();
 	type StakingTokenPriceQueryId = ();
 	type UpdateStakeInterval = ();

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -150,6 +150,10 @@ impl tellor::Config for Test {
 	type Token = Balances;
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
+	type MinimumStakeAmount = ();
+	type StakeAmountCurrencyTarget = ();
+	type StakingTokenPriceQueryId = ();
+	type UpdateStakeInterval = ();
 }
 
 pub struct ValueConverter;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -16,7 +16,7 @@
 
 use crate as tellor;
 use crate::{
-	types::Address, xcm::ContractLocation, EnsureGovernance, EnsureStaking,
+	constants::HOURS, types::Address, xcm::ContractLocation, EnsureGovernance, EnsureStaking,
 	Error::ValueConversionError,
 };
 use frame_support::{
@@ -26,7 +26,7 @@ use frame_support::{
 };
 use frame_system as system;
 use once_cell::sync::Lazy;
-use sp_core::{ConstU32, ConstU8, H256};
+use sp_core::{ConstU128, ConstU32, ConstU8, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup},
@@ -114,7 +114,7 @@ static GOVERNANCE: Lazy<[u8; 20]> = Lazy::new(|| Address::random().into());
 static STAKING: Lazy<[u8; 20]> = Lazy::new(|| Address::random().into());
 
 parameter_types! {
-	pub const MinimumStakeAmount: u128 = 100 * 10u128.pow(18);
+	pub const MinimumStakeAmount: u128 = 100 * 10u128.pow(18); // 100 TRB
 	pub const TellorPalletId: PalletId = PalletId(*b"py/tellr");
 	pub const ParachainId: u32 = PARA_ID;
 	pub TellorRegistry: ContractLocation = (EVM_PARA_ID, *REGISTRY).into();
@@ -147,15 +147,15 @@ impl tellor::Config for Test {
 	type Price = u128;
 	type RegistrationOrigin = system::EnsureRoot<AccountId>;
 	type Registry = TellorRegistry;
+	type StakeAmountCurrencyTarget = ConstU128<1_500>;
 	type Staking = TellorStaking;
 	type StakingOrigin = EnsureStaking;
+	type StakingTokenPriceQueryId = StakingTokenPriceQueryId;
 	type Time = Timestamp;
 	type Token = Balances;
+	type UpdateStakeAmountInterval = ConstU64<{ 12 * HOURS }>;
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
-	type StakeAmountCurrencyTarget = ();
-	type StakingTokenPriceQueryId = StakingTokenPriceQueryId;
-	type UpdateStakeAmountInterval = ();
 }
 
 pub struct ValueConverter;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -155,7 +155,7 @@ impl tellor::Config for Test {
 	type Xcm = TestSendXcm;
 	type StakeAmountCurrencyTarget = ();
 	type StakingTokenPriceQueryId = StakingTokenPriceQueryId;
-	type UpdateStakeInterval = ();
+	type UpdateStakeAmountInterval = ();
 }
 
 pub struct ValueConverter;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -120,6 +120,7 @@ parameter_types! {
 	pub TellorRegistry: ContractLocation = (EVM_PARA_ID, *REGISTRY).into();
 	pub TellorGovernance: ContractLocation = (EVM_PARA_ID, *GOVERNANCE).into();
 	pub TellorStaking: ContractLocation = (EVM_PARA_ID, *STAKING).into();
+	pub StakingTokenPriceQueryId: H256 = H256([211,194,112,119,36,198,191,243,89,99,24,187,3,60,229,109,166,126,119,8,208,251,201,107,66,216,126,12,172,199,241,136]);
 }
 
 impl tellor::Config for Test {
@@ -153,7 +154,7 @@ impl tellor::Config for Test {
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
 	type StakeAmountCurrencyTarget = ();
-	type StakingTokenPriceQueryId = ();
+	type StakingTokenPriceQueryId = StakingTokenPriceQueryId;
 	type UpdateStakeInterval = ();
 }
 

--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -47,8 +47,8 @@ fn claim_tip_ensures() {
 	let claimed = ext.execute_with(|| {
 		with_block(|| {
 			configure_parachain();
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
-			deposit_stake(another_reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
+			deposit_stake(another_reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 
 			Balances::make_free_balance_be(&feed_creator, token(1_010) + 1);
 			feed_id = create_feed(
@@ -350,7 +350,7 @@ fn claim_tip() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 
 			Balances::make_free_balance_be(&feed_creator, token(1_000) + 1);
 			feed_id = create_feed(
@@ -438,7 +438,7 @@ fn _get_reward_amount() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		});
 	});
 
@@ -790,7 +790,7 @@ fn get_reward_claimed_status() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 			timestamp = super::now();
 			Balances::make_free_balance_be(&feed_creator, token(3));
 			feed_id = create_feed(
@@ -846,8 +846,8 @@ fn tip() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
-			deposit_stake(another_reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
+			deposit_stake(another_reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
@@ -976,8 +976,8 @@ fn claim_onetime_tip() {
 	ext.execute_with(|| {
 		with_block(|| {
 			configure_parachain();
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
-			deposit_stake(another_reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
+			deposit_stake(another_reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		});
 	});
 
@@ -1324,7 +1324,7 @@ fn get_past_tips() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		});
 	});
 
@@ -1420,7 +1420,7 @@ fn get_past_tip_by_index() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		});
 	});
 
@@ -1518,7 +1518,7 @@ fn get_past_tip_count() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		});
 	});
 
@@ -1579,7 +1579,7 @@ fn get_funded_feeds() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 			Balances::make_free_balance_be(&feed_creator, token(3) + 1);
 			create_feed(
 				feed_creator,
@@ -1727,8 +1727,8 @@ fn get_funded_query_ids() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
-			deposit_stake(another_reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
+			deposit_stake(another_reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(another_reporter),
@@ -1997,9 +1997,9 @@ fn get_reward_amount() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter_1, STAKE_AMOUNT, Address::random());
-			deposit_stake(reporter_2, STAKE_AMOUNT, Address::random());
-			deposit_stake(reporter_3, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter_1, MINIMUM_STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter_2, MINIMUM_STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter_3, MINIMUM_STAKE_AMOUNT, Address::random());
 		});
 	});
 
@@ -2234,9 +2234,9 @@ fn get_reward_claim_status_list() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter_1, STAKE_AMOUNT, Address::random());
-			deposit_stake(reporter_2, STAKE_AMOUNT, Address::random());
-			deposit_stake(reporter_3, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter_1, MINIMUM_STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter_2, MINIMUM_STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter_3, MINIMUM_STAKE_AMOUNT, Address::random());
 		});
 	});
 

--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -46,7 +46,7 @@ fn claim_tip_ensures() {
 	// Prerequisites
 	let claimed = ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
+			configure_parachain();
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 			deposit_stake(another_reporter, STAKE_AMOUNT, Address::random());
 
@@ -350,7 +350,6 @@ fn claim_tip() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 
 			Balances::make_free_balance_be(&feed_creator, token(1_000) + 1);
@@ -439,7 +438,6 @@ fn _get_reward_amount() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 		});
 	});
@@ -792,7 +790,6 @@ fn get_reward_claimed_status() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 			timestamp = super::now();
 			Balances::make_free_balance_be(&feed_creator, token(3));
@@ -849,7 +846,6 @@ fn tip() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 			deposit_stake(another_reporter, STAKE_AMOUNT, Address::random());
 
@@ -979,7 +975,7 @@ fn claim_onetime_tip() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
+			configure_parachain();
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 			deposit_stake(another_reporter, STAKE_AMOUNT, Address::random());
 		});
@@ -1328,7 +1324,6 @@ fn get_past_tips() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 		});
 	});
@@ -1425,7 +1420,6 @@ fn get_past_tip_by_index() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 		});
 	});
@@ -1524,7 +1518,6 @@ fn get_past_tip_count() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 		});
 	});
@@ -1586,7 +1579,6 @@ fn get_funded_feeds() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 			Balances::make_free_balance_be(&feed_creator, token(3) + 1);
 			create_feed(
@@ -1735,7 +1727,6 @@ fn get_funded_query_ids() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 			deposit_stake(another_reporter, STAKE_AMOUNT, Address::random());
 
@@ -2006,7 +1997,6 @@ fn get_reward_amount() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter_1, STAKE_AMOUNT, Address::random());
 			deposit_stake(reporter_2, STAKE_AMOUNT, Address::random());
 			deposit_stake(reporter_3, STAKE_AMOUNT, Address::random());
@@ -2244,7 +2234,6 @@ fn get_reward_claim_status_list() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter_1, STAKE_AMOUNT, Address::random());
 			deposit_stake(reporter_2, STAKE_AMOUNT, Address::random());
 			deposit_stake(reporter_3, STAKE_AMOUNT, Address::random());

--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -428,7 +428,7 @@ fn claim_tip() {
 }
 
 #[test]
-fn _get_reward_amount() {
+fn do_get_reward_amount() {
 	let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
 	let query_id: H256 = keccak_256(query_data.as_ref()).into();
 	let feed_creator = 2;

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -37,8 +37,8 @@ fn begin_dispute() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			configure_parachain();
+			deposit_stake(reporter, STAKE_AMOUNT, Address::random())
 		})
 	});
 
@@ -118,7 +118,7 @@ fn begin_dispute() {
 				balance_before_begin_dispute -
 					balance_after_begin_dispute -
 					U256ToBalance::convert(
-						Tellor::convert(StakeAmount::<Test>::get().unwrap()).unwrap() * PRICE
+						Tellor::convert(StakeAmount::<Test>::get()).unwrap() * PRICE
 					) / 10 == 0,
 				"dispute fee paid should be correct"
 			);
@@ -199,8 +199,8 @@ fn begin_dispute_by_non_reporter() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			configure_parachain();
+			deposit_stake(reporter, STAKE_AMOUNT, Address::random())
 		})
 	});
 
@@ -276,7 +276,7 @@ fn begin_dispute_by_non_reporter() {
 				balance_before_begin_dispute -
 					balance_after_begin_dispute -
 					U256ToBalance::convert(
-						Tellor::convert(StakeAmount::<Test>::get().unwrap()).unwrap() * PRICE
+						Tellor::convert(StakeAmount::<Test>::get()).unwrap() * PRICE
 					) / 10 == 0,
 				"dispute fee paid should be correct"
 			);
@@ -349,7 +349,7 @@ fn begin_dispute_by_non_reporter() {
 fn begins_dispute_xcm() {
 	new_test_ext().execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
+			configure_parachain();
 
 			let reporter = 1;
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
@@ -403,7 +403,6 @@ fn begin_dispute_checks_max_vote_rounds() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
 			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 		})
 	});
@@ -444,7 +443,7 @@ fn execute_vote() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
+			configure_parachain();
 			deposit_stake(dispute_reporter, STAKE_AMOUNT, Address::random())
 		})
 	});
@@ -612,7 +611,7 @@ fn tally_votes() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L143
 	ext.execute_with(|| {
@@ -667,7 +666,7 @@ fn vote() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L170
 	ext.execute_with(|| {
@@ -771,7 +770,7 @@ fn did_vote() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L248
 	ext.execute_with(|| {
@@ -818,7 +817,7 @@ fn get_dispute_info() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L260
 	ext.execute_with(|| {
@@ -864,7 +863,7 @@ fn get_disputes_by_reporter() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
+			configure_parachain();
 			deposit_stake(dispute_initiator, STAKE_AMOUNT, Address::random())
 		})
 	});
@@ -944,7 +943,7 @@ fn get_open_disputes_on_id() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L274
 	ext.execute_with(|| {
@@ -1019,7 +1018,7 @@ fn get_vote_count() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L298
 	ext.execute_with(|| {
@@ -1087,7 +1086,7 @@ fn get_vote_info() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L322
 	ext.execute_with(|| {
@@ -1169,7 +1168,7 @@ fn get_vote_rounds() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L361
 	ext.execute_with(|| {
@@ -1221,7 +1220,7 @@ fn get_vote_tally_by_address() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L383
 	ext.execute_with(|| {
@@ -1301,7 +1300,7 @@ fn get_tips_by_address() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L404
 	ext.execute_with(|| {
@@ -1371,7 +1370,7 @@ fn invalid_dispute() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
+			configure_parachain();
 			super::deposit_stake(reporter, STAKE_AMOUNT, Address::random());
 		})
 	});
@@ -1421,7 +1420,7 @@ fn slash_dispute_initiator() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	ext.execute_with(|| {
 		Balances::make_free_balance_be(&another_reporter, token(1_000));

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -38,7 +38,7 @@ fn begin_dispute() {
 	ext.execute_with(|| {
 		with_block(|| {
 			configure_parachain();
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random())
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random())
 		})
 	});
 
@@ -57,7 +57,7 @@ fn begin_dispute() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				another_reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_noop!(
@@ -142,7 +142,7 @@ fn begin_dispute() {
 				Origin::Governance.into(),
 				reporter,
 				another_reporter,
-				STAKE_AMOUNT.into()
+				MINIMUM_STAKE_AMOUNT.into()
 			));
 		});
 
@@ -160,7 +160,7 @@ fn begin_dispute() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				3,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -200,7 +200,7 @@ fn begin_dispute_by_non_reporter() {
 	ext.execute_with(|| {
 		with_block(|| {
 			configure_parachain();
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random())
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random())
 		})
 	});
 
@@ -300,7 +300,7 @@ fn begin_dispute_by_non_reporter() {
 				Origin::Governance.into(),
 				reporter,
 				another_reporter,
-				STAKE_AMOUNT.into()
+				MINIMUM_STAKE_AMOUNT.into()
 			));
 		});
 
@@ -318,7 +318,7 @@ fn begin_dispute_by_non_reporter() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				3,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -352,7 +352,7 @@ fn begins_dispute_xcm() {
 			configure_parachain();
 
 			let reporter = 1;
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 
 			let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
 			let query_id = keccak_256(query_data.as_ref()).into();
@@ -403,7 +403,7 @@ fn begin_dispute_checks_max_vote_rounds() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		})
 	});
 
@@ -444,7 +444,7 @@ fn execute_vote() {
 	ext.execute_with(|| {
 		with_block(|| {
 			configure_parachain();
-			deposit_stake(dispute_reporter, STAKE_AMOUNT, Address::random())
+			deposit_stake(dispute_reporter, MINIMUM_STAKE_AMOUNT, Address::random())
 		})
 	});
 
@@ -454,7 +454,7 @@ fn execute_vote() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter_1,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_noop!(Tellor::execute_vote(H256::random(), result), Error::InvalidDispute);
@@ -547,7 +547,7 @@ fn execute_vote() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter_3,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -622,7 +622,7 @@ fn tally_votes() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -677,7 +677,7 @@ fn vote() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter_2,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -778,7 +778,7 @@ fn did_vote() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -825,7 +825,7 @@ fn get_dispute_info() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -864,7 +864,7 @@ fn get_disputes_by_reporter() {
 	ext.execute_with(|| {
 		with_block(|| {
 			configure_parachain();
-			deposit_stake(dispute_initiator, STAKE_AMOUNT, Address::random())
+			deposit_stake(dispute_initiator, MINIMUM_STAKE_AMOUNT, Address::random())
 		})
 	});
 
@@ -873,7 +873,7 @@ fn get_disputes_by_reporter() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -951,7 +951,7 @@ fn get_open_disputes_on_id() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -967,7 +967,7 @@ fn get_open_disputes_on_id() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				another_reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -1027,7 +1027,7 @@ fn get_vote_count() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -1094,7 +1094,7 @@ fn get_vote_info() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -1176,7 +1176,7 @@ fn get_vote_rounds() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -1228,7 +1228,7 @@ fn get_vote_tally_by_address() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -1252,7 +1252,7 @@ fn get_vote_tally_by_address() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				another_reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			assert_ok!(Tellor::submit_value(
@@ -1308,7 +1308,7 @@ fn get_tips_by_address() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 			Balances::make_free_balance_be(&user, token(1_000) + 1);
@@ -1371,7 +1371,7 @@ fn invalid_dispute() {
 	ext.execute_with(|| {
 		with_block(|| {
 			configure_parachain();
-			super::deposit_stake(reporter, STAKE_AMOUNT, Address::random());
+			super::deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		})
 	});
 
@@ -1439,7 +1439,7 @@ fn slash_dispute_initiator() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 
@@ -1454,7 +1454,7 @@ fn slash_dispute_initiator() {
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				another_reporter,
-				STAKE_AMOUNT.into(),
+				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -49,7 +49,7 @@ type Configuration = crate::pallet::Configuration<Test>;
 type Error = crate::Error<Test>;
 type U256ToBalance = crate::types::U256ToBalance<Test>;
 
-const STAKE_AMOUNT: u128 = 100 * TRB;
+const MINIMUM_STAKE_AMOUNT: u128 = 100 * TRB;
 const TRB: u128 = 10u128.pow(DECIMALS);
 
 fn trb(amount: impl Into<f64>) -> Tributes {
@@ -236,7 +236,7 @@ fn register() {
 				require_weight_at_most,
 				gas_limit
 			));
-			assert_eq!(StakeAmount::<Test>::get(), STAKE_AMOUNT.into());
+			assert_eq!(StakeAmount::<Test>::get(), MINIMUM_STAKE_AMOUNT.into());
 			assert_eq!(
 				Configuration::get().unwrap(),
 				Config {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -100,11 +100,11 @@ fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<Tributes>, addre
 	));
 }
 
-fn register_parachain(stake_amount: impl Into<Tributes>) {
+// Configures the parachain for remote transact calls to controller contracts
+fn configure_parachain() {
 	let self_reserve = MultiLocation { parents: 0, interior: X1(PalletInstance(3)) };
 	assert_ok!(Tellor::register(
 		RuntimeOrigin::root(),
-		stake_amount.into(),
 		Box::new(MultiAsset { id: Concrete(self_reserve), fun: Fungible(300_000_000_000_000u128) }),
 		WeightLimit::Unlimited,
 		1000,
@@ -226,21 +226,17 @@ fn register() {
 			for origin in
 				vec![RuntimeOrigin::signed(0), Origin::Governance.into(), Origin::Staking.into()]
 			{
-				assert_noop!(
-					Tellor::register(origin, trb(0), fees.clone(), Unlimited, 0, 0),
-					BadOrigin
-				);
+				assert_noop!(Tellor::register(origin, fees.clone(), Unlimited, 0, 0), BadOrigin);
 			}
 
 			assert_ok!(Tellor::register(
 				RuntimeOrigin::root(),
-				STAKE_AMOUNT.into(),
 				fees.clone(),
 				weight_limit.clone(),
 				require_weight_at_most,
 				gas_limit
 			));
-			assert_eq!(StakeAmount::<Test>::get().unwrap(), STAKE_AMOUNT.into());
+			assert_eq!(StakeAmount::<Test>::get(), STAKE_AMOUNT.into());
 			assert_eq!(
 				Configuration::get().unwrap(),
 				Config {
@@ -252,9 +248,7 @@ fn register() {
 					gas_limit
 				}
 			);
-			System::assert_has_event(
-				Event::Configured { stake_amount: STAKE_AMOUNT.into() }.into(),
-			);
+			System::assert_has_event(Event::Configured {}.into());
 
 			assert_eq!(
 				sent_xcm(),

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -1627,7 +1627,7 @@ fn update_stake_amount() {
 			));
 
 			// Test no reported TRB price
-			assert_ok!(Tellor::_update_stake_amount());
+			assert_noop!(Tellor::_update_stake_amount(), Error::InvalidStakingTokenPrice);
 			println!("REQUIRED_STAKE: {}", REQUIRED_STAKE);
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 
@@ -1639,7 +1639,7 @@ fn update_stake_amount() {
 				0,
 				query_data.clone()
 			));
-			assert_ok!(Tellor::_update_stake_amount());
+			assert_noop!(Tellor::_update_stake_amount(), Error::InvalidStakingTokenPrice);
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 		});
 

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -1617,8 +1617,6 @@ fn update_stake_amount() {
 	ext.execute_with(|| {
 		with_block(|| {
 			// Setup
-			// 	await token.mint(accounts[1].address, web3.utils.toWei("10000"));
-			// 	await token.connect(accounts[1]).approve(tellor.address, web3.utils.toWei("10000"))
 			assert_ok!(Tellor::report_stake_deposited(
 				Origin::Staking.into(),
 				reporter,
@@ -1627,7 +1625,10 @@ fn update_stake_amount() {
 			));
 
 			// Test no reported TRB price
-			assert_noop!(Tellor::_update_stake_amount(), Error::InvalidStakingTokenPrice);
+			assert_noop!(
+				Tellor::update_stake_amount(RuntimeOrigin::signed(reporter)),
+				Error::InvalidStakingTokenPrice
+			);
 			println!("REQUIRED_STAKE: {}", REQUIRED_STAKE);
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 
@@ -1639,13 +1640,16 @@ fn update_stake_amount() {
 				0,
 				query_data.clone()
 			));
-			assert_noop!(Tellor::_update_stake_amount(), Error::InvalidStakingTokenPrice);
+			assert_noop!(
+				Tellor::update_stake_amount(RuntimeOrigin::signed(reporter)),
+				Error::InvalidStakingTokenPrice
+			);
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 		});
 
 		// Test updating when 12 hrs have passed
 		with_block_after(60 * 60 * 12, || {
-			assert_ok!(Tellor::_update_stake_amount());
+			assert_ok!(Tellor::update_stake_amount(RuntimeOrigin::signed(reporter)));
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 		});
 
@@ -1678,7 +1682,7 @@ fn update_stake_amount() {
 			));
 		});
 		with_block_after(60 * 60 * 12, || {
-			assert_ok!(Tellor::_update_stake_amount());
+			assert_ok!(Tellor::update_stake_amount(RuntimeOrigin::signed(reporter)));
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 		});
 
@@ -1694,7 +1698,10 @@ fn update_stake_amount() {
 			));
 		});
 		with_block_after(86_400 / 2, || {
-			assert_noop!(Tellor::_update_stake_amount(), Error::InvalidStakingTokenPrice);
+			assert_noop!(
+				Tellor::update_stake_amount(RuntimeOrigin::signed(reporter)),
+				Error::InvalidStakingTokenPrice
+			);
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 		});
 
@@ -1710,7 +1717,10 @@ fn update_stake_amount() {
 			));
 		});
 		with_block_after(86_400 / 2, || {
-			assert_noop!(Tellor::_update_stake_amount(), Error::InvalidStakingTokenPrice);
+			assert_noop!(
+				Tellor::update_stake_amount(RuntimeOrigin::signed(reporter)),
+				Error::InvalidStakingTokenPrice
+			);
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 		});
 
@@ -1726,7 +1736,10 @@ fn update_stake_amount() {
 			));
 		});
 		with_block_after(86_400 / 2, || {
-			assert_noop!(Tellor::_update_stake_amount(), Error::InvalidStakingTokenPrice);
+			assert_noop!(
+				Tellor::update_stake_amount(RuntimeOrigin::signed(reporter)),
+				Error::InvalidStakingTokenPrice
+			);
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 		});
 
@@ -1759,7 +1772,7 @@ fn update_stake_amount() {
 			));
 		});
 		with_block_after(60 * 60 * 12, || {
-			assert_ok!(Tellor::_update_stake_amount());
+			assert_ok!(Tellor::update_stake_amount(RuntimeOrigin::signed(reporter)));
 			assert_eq!(Tellor::get_stake_amount(), MINIMUM_STAKE_AMOUNT.into());
 		});
 	});

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -39,7 +39,7 @@ fn deposit_stake() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L86
 	ext.execute_with(|| {
@@ -121,7 +121,7 @@ fn remove_value() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			register_parachain(STAKE_AMOUNT);
+			configure_parachain();
 			super::deposit_stake(another_reporter, STAKE_AMOUNT, Address::random());
 		})
 	});
@@ -178,7 +178,7 @@ fn request_stake_withdraw() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L151
 	ext.execute_with(|| {
@@ -288,7 +288,7 @@ fn slash_reporter() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L195
 	ext.execute_with(|| {
@@ -472,9 +472,6 @@ fn submit_value() {
 	let address = Address::random();
 	let mut ext = new_test_ext();
 
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
-
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L277
 	ext.execute_with(|| {
 		with_block(|| {
@@ -637,7 +634,7 @@ fn withdraw_stake() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L323
 	ext.execute_with(|| {
@@ -704,9 +701,6 @@ fn get_block_number_by_timestamp() {
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
 
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
-
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L345
 	ext.execute_with(|| {
 		with_block(|| {
@@ -738,9 +732,6 @@ fn get_current_value() {
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
 
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
-
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L352
 	ext.execute_with(|| {
 		with_block(|| {
@@ -768,9 +759,6 @@ fn get_new_value_count_by_query_id() {
 	let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
-
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L363
 	ext.execute_with(|| {
@@ -809,9 +797,6 @@ fn get_report_details() {
 	let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
-
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L372
 	ext.execute_with(|| {
@@ -876,9 +861,6 @@ fn get_reporter_by_timestamp() {
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
 
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
-
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L402
 	ext.execute_with(|| {
 		with_block(|| {
@@ -907,9 +889,6 @@ fn get_reporter_last_timestamp() {
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
 
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
-
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L409
 	ext.execute_with(|| {
 		with_block(|| {
@@ -937,9 +916,6 @@ fn get_reports_submitted_by_address() {
 	let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
-
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L419
 	ext.execute_with(|| {
@@ -979,9 +955,6 @@ fn get_reports_submitted_by_address_and_query_id() {
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
 
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
-
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L429
 	ext.execute_with(|| {
 		with_block(|| {
@@ -1017,11 +990,7 @@ fn get_reports_submitted_by_address_and_query_id() {
 fn get_stake_amount() {
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L439
 	new_test_ext().execute_with(|| {
-		with_block(|| {
-			assert_eq!(Tellor::get_stake_amount(), trb(0));
-			register_parachain(STAKE_AMOUNT);
-			assert_eq!(Tellor::get_stake_amount(), STAKE_AMOUNT.into());
-		})
+		with_block(|| assert_eq!(Tellor::get_stake_amount(), STAKE_AMOUNT.into()))
 	});
 }
 
@@ -1034,7 +1003,7 @@ fn get_staker_info() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L443
 	ext.execute_with(|| {
@@ -1083,9 +1052,6 @@ fn get_time_of_last_new_value() {
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
 
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
-
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L461
 	ext.execute_with(|| {
 		with_block(|| {
@@ -1113,9 +1079,6 @@ fn get_timestamp_by_query_and_index() {
 	let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
-
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L471
 	ext.execute_with(|| {
@@ -1155,9 +1118,6 @@ fn get_timestamp_index_by_timestamp() {
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
 
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
-
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L481
 	ext.execute_with(|| {
 		with_block(|| {
@@ -1196,7 +1156,7 @@ fn get_total_stake_amount() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L491
 	ext.execute_with(|| {
@@ -1225,7 +1185,7 @@ fn get_total_stakers() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L502
 	ext.execute_with(|| {
@@ -1274,7 +1234,7 @@ fn is_in_dispute() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
+	ext.execute_with(|| with_block(|| configure_parachain()));
 
 	ext.execute_with(|| {
 		with_block(|| {
@@ -1313,9 +1273,6 @@ fn retrieve_data() {
 	let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
-
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L519
 	ext.execute_with(|| {
@@ -1403,9 +1360,6 @@ fn get_index_for_data_before() {
 	let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
-
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L519
 	ext.execute_with(|| {
@@ -1550,9 +1504,6 @@ fn get_data_before() {
 	let query_data: QueryDataOf<Test> = spot_price("dot", "usd").try_into().unwrap();
 	let query_id = keccak_256(query_data.as_ref()).into();
 	let mut ext = new_test_ext();
-
-	// Prerequisites
-	ext.execute_with(|| with_block(|| register_parachain(STAKE_AMOUNT)));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L697
 	ext.execute_with(|| {


### PR DESCRIPTION
- adds `MinimumStakeAmount` config item, which is used by `StakeAmount<T>` storage item until value set
- adds `StakeAmountCurrencyTarget` config item, for setting stake amount target in some currency (e.g. USD 1,500)
- adds `StakingTokenPriceQueryId` config item, for obtaining rate for converting between TRB and currency from oracle
- adds `UpdateStakeAmountInterval` config item, for configuring how frequently the stake amount is updated via hook
  - hook compares current time vs `LastStakeAmountUpdate<T>  + interval`, where interval is configured interval or some minimum interval
- adds `update_stake_amount` dispatchable function, updating the stake amount based on oracle price and stake amount currency target
- removes `stake_amount` from `register` dispatchable function as no longer required

Closes #43 