### PR TITLE
fix: separate configure from register

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -112,6 +112,7 @@ impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type Balance = Balance;
+	type ConfigureOrigin = frame_system::EnsureRoot<AccountId>;
 	type Decimals = ();
 	type Fee = ();
 	type Governance = ();
@@ -130,7 +131,7 @@ impl tellor::Config for Test {
 	type PalletId = TellorPalletId;
 	type ParachainId = ();
 	type Price = u32;
-	type RegistrationOrigin = frame_system::EnsureRoot<AccountId>;
+	type RegisterOrigin = frame_system::EnsureRoot<AccountId>;
 	type Registry = ();
 	type StakeAmountCurrencyTarget = ();
 	type Staking = ();

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -127,6 +127,7 @@ impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
 	type Balance = Balance;
+	type ConfigureOrigin = system::EnsureRoot<AccountId>;
 	type Decimals = ConstU8<12>;
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
@@ -145,7 +146,7 @@ impl tellor::Config for Test {
 	type PalletId = TellorPalletId;
 	type ParachainId = ParachainId;
 	type Price = u128;
-	type RegistrationOrigin = system::EnsureRoot<AccountId>;
+	type RegisterOrigin = system::EnsureRoot<AccountId>;
 	type Registry = TellorRegistry;
 	type StakeAmountCurrencyTarget = ConstU128<{ 500 * 10u128.pow(18) }>;
 	type Staking = TellorStaking;

--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -46,7 +46,7 @@ fn claim_tip_ensures() {
 	// Prerequisites
 	let claimed = ext.execute_with(|| {
 		with_block(|| {
-			configure_parachain();
+			configure();
 			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 			deposit_stake(another_reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 
@@ -975,7 +975,7 @@ fn claim_onetime_tip() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			configure_parachain();
+			configure();
 			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 			deposit_stake(another_reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		});

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -37,7 +37,7 @@ fn begin_dispute() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			configure_parachain();
+			configure();
 			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random())
 		})
 	});
@@ -203,7 +203,7 @@ fn begin_dispute_by_non_reporter() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			configure_parachain();
+			configure();
 			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random())
 		})
 	});
@@ -357,7 +357,7 @@ fn begin_dispute_by_non_reporter() {
 fn begins_dispute_xcm() {
 	new_test_ext().execute_with(|| {
 		with_block(|| {
-			configure_parachain();
+			configure();
 
 			let reporter = 1;
 			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
@@ -451,7 +451,7 @@ fn execute_vote() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			configure_parachain();
+			configure();
 			deposit_stake(dispute_reporter, MINIMUM_STAKE_AMOUNT, Address::random())
 		})
 	});
@@ -640,7 +640,7 @@ fn tally_votes() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L143
 	ext.execute_with(|| {
@@ -720,7 +720,7 @@ fn vote() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L170
 	ext.execute_with(|| {
@@ -828,7 +828,7 @@ fn did_vote() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L248
 	ext.execute_with(|| {
@@ -875,7 +875,7 @@ fn get_dispute_info() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L260
 	ext.execute_with(|| {
@@ -921,7 +921,7 @@ fn get_disputes_by_reporter() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			configure_parachain();
+			configure();
 			deposit_stake(dispute_initiator, MINIMUM_STAKE_AMOUNT, Address::random())
 		})
 	});
@@ -1005,7 +1005,7 @@ fn get_open_disputes_on_id() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L274
 	ext.execute_with(|| {
@@ -1084,7 +1084,7 @@ fn get_vote_count() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L298
 	ext.execute_with(|| {
@@ -1156,7 +1156,7 @@ fn get_vote_info() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L322
 	ext.execute_with(|| {
@@ -1242,7 +1242,7 @@ fn get_vote_rounds() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L361
 	ext.execute_with(|| {
@@ -1298,7 +1298,7 @@ fn get_vote_tally_by_address() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L383
 	ext.execute_with(|| {
@@ -1378,7 +1378,7 @@ fn get_tips_by_address() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L404
 	ext.execute_with(|| {
@@ -1452,8 +1452,8 @@ fn invalid_dispute() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			configure_parachain();
-			super::deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
+			configure();
+			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		})
 	});
 
@@ -1498,7 +1498,7 @@ fn slash_dispute_initiator() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	ext.execute_with(|| {
 		Balances::make_free_balance_be(&another_reporter, token(1_000));

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -45,7 +45,7 @@ fn deposit_stake() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L86
 	ext.execute_with(|| {
@@ -127,7 +127,7 @@ fn remove_value() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			configure_parachain();
+			configure();
 			super::deposit_stake(another_reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		})
 	});
@@ -184,7 +184,7 @@ fn request_stake_withdraw() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L151
 	ext.execute_with(|| {
@@ -294,7 +294,7 @@ fn slash_reporter() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L195
 	ext.execute_with(|| {
@@ -661,7 +661,7 @@ fn withdraw_stake() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L323
 	ext.execute_with(|| {
@@ -1023,7 +1023,7 @@ fn get_staker_info() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L443
 	ext.execute_with(|| {
@@ -1176,7 +1176,7 @@ fn get_total_stake_amount() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L491
 	ext.execute_with(|| {
@@ -1205,7 +1205,7 @@ fn get_total_stakers() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	// Based on https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L502
 	ext.execute_with(|| {
@@ -1254,7 +1254,7 @@ fn is_in_dispute() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	ext.execute_with(|| with_block(|| configure_parachain()));
+	ext.execute_with(|| with_block(|| configure()));
 
 	ext.execute_with(|| {
 		with_block(|| {


### PR DESCRIPTION
Separates the configuration of fees used for cross-chain transact from the registration of the parachain with registry controller contract, as the current implementation mixes concerns.

- adds a `ConfigureOrigin` to config to allow parachain to specify who can call `configure()`, separate to the `RegisterOrigin` for the the `register`/`deregister` calls.
- renames `xcm::transact_with_config()` function to `xcm::transact()` as overload no longer required.

Closes #47 