### PR TITLE
feat: convert dispute fee to local balance using oracle

### DIFF
--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -296,7 +296,7 @@ sp_api::decl_runtime_apis! {
 		/// Get the latest dispute fee.
 		/// # Returns
 		/// The latest dispute fee.
-		fn get_dispute_fee() -> Option<Balance>;
+		fn get_dispute_fee() -> Balance;
 
 		/// Returns the dispute identifiers for a reporter.
 		/// # Arguments

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -117,7 +117,7 @@ impl tellor::Config for Test {
 	type Fee = ();
 	type Governance = ();
 	type GovernanceOrigin = EnsureGovernance;
-	type InitialTokenPrice = ();
+	type InitialDisputeFee = ();
 	type MaxClaimTimestamps = ();
 	type MaxFeedsPerQuery = ();
 	type MaxFundedFeeds = ();
@@ -138,9 +138,9 @@ impl tellor::Config for Test {
 	type Staking = ();
 	type StakingOrigin = EnsureStaking;
 	type StakingTokenPriceQueryId = ();
+	type StakingToLocalTokenPriceQueryId = ();
 	type Time = Time;
 	type Token = Balances;
-	type TokenPriceQueryId = ();
 	type UpdateStakeAmountInterval = ();
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -26,7 +26,7 @@ use frame_support::{
 	BoundedVec, PalletId,
 };
 use sp_api::mock_impl_runtime_apis;
-use sp_core::{ConstU32, H256, U256};
+use sp_core::{ConstU128, ConstU32, H256, U256};
 use sp_runtime::{
 	generic::BlockId,
 	testing::Header,
@@ -43,7 +43,7 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 type AccountId = u64;
-type Balance = u64;
+type Balance = u128;
 type BlockNumber = u64;
 type MaxValueLength = ConstU32<4>;
 type StakeInfo = tellor::StakeInfo<Balance, <Test as tellor::Config>::MaxQueriesPerReporter>;
@@ -92,7 +92,7 @@ impl pallet_balances::Config for Test {
 	type Balance = Balance;
 	type DustRemoval = ();
 	type RuntimeEvent = RuntimeEvent;
-	type ExistentialDeposit = ConstU64<1>;
+	type ExistentialDeposit = ConstU128<1>;
 	type AccountStore = System;
 	type WeightInfo = ();
 	type MaxLocks = ();
@@ -117,6 +117,7 @@ impl tellor::Config for Test {
 	type Fee = ();
 	type Governance = ();
 	type GovernanceOrigin = EnsureGovernance;
+	type InitialTokenPrice = ();
 	type MaxClaimTimestamps = ();
 	type MaxFeedsPerQuery = ();
 	type MaxFundedFeeds = ();
@@ -139,6 +140,7 @@ impl tellor::Config for Test {
 	type StakingTokenPriceQueryId = ();
 	type Time = Time;
 	type Token = Balances;
+	type TokenPriceQueryId = ();
 	type UpdateStakeAmountInterval = ();
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
@@ -326,7 +328,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::did_vote(dispute_id, vote_round, voter)
 		}
 
-		fn get_dispute_fee() -> Option<Balance> {
+		fn get_dispute_fee() -> Balance {
 			tellor::Pallet::<Test>::get_dispute_fee()
 		}
 
@@ -706,7 +708,7 @@ mod governance {
 	#[test]
 	fn get_dispute_fee() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(Test.get_dispute_fee(&BLOCKID).unwrap(), Some(0));
+			assert_eq!(Test.get_dispute_fee(&BLOCKID).unwrap(), 0);
 		});
 	}
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -28,6 +28,26 @@ impl<T: Config> Pallet<T> {
 		T::ValueConverter::convert(value.into_inner())
 	}
 
+	/// Calculates the latest dispute fee based on the supplied price.
+	/// # Arguments
+	/// * `price` - The current staking token to local balance price.
+	/// # Returns
+	/// The latest dispute fee.
+	pub(super) fn calculate_dispute_fee(price: impl Into<U256>) -> BalanceOf<T> {
+		<U256ToBalance<T>>::convert(
+			Self::convert(
+				<StakeAmount<T>>::get()
+					.checked_div(10.into())
+					.expect("other is non-zero; qed")
+					.checked_mul(price.into())
+					.unwrap() // todo: depends on the initial token price configured, could overflow
+					.checked_div(U256::from(10u128.pow(DECIMALS)))
+					.expect("other is non-zero; qed"),
+			)
+			.unwrap(), // todo: depends on the number of decimals configured, could overflow
+		)
+	}
+
 	/// Converts a stake amount to a local balance amount.
 	/// # Arguments
 	/// * `stake_amount` - The amount staked.
@@ -445,24 +465,8 @@ impl<T: Config> Pallet<T> {
 	/// Get the latest dispute fee.
 	/// # Returns
 	/// The latest dispute fee.
-	pub fn get_dispute_fee() -> Option<BalanceOf<T>> {
-		<StakeAmount<T>>::get()
-			.checked_div(U256::from(10))
-			.and_then(|a| {
-				// todo: use rate from oracle
-				const UNIT: u128 = 10u128.pow(DECIMALS);
-				const PRICE: Option<u128> = Some(5 * UNIT); // spot price query uses 18 decimal places as per data spec
-
-				PRICE
-					.map(U256::from)
-					// Convert amount into local balance amount based on price
-					.and_then(|price| {
-						a.checked_mul(price).and_then(|a| a.checked_div(U256::from(UNIT)))
-					})
-			})
-			// Convert to local number of decimals
-			.and_then(|a| Self::convert(a).ok())
-			.map(U256ToBalance::<T>::convert)
+	pub fn get_dispute_fee() -> BalanceOf<T> {
+		<DisputeFee<T>>::get()
 	}
 
 	/// Returns information on a dispute for a given identifier.
@@ -1172,6 +1176,28 @@ impl<T: Config> Pallet<T> {
 		10u128
 			.checked_pow(T::Decimals::get().into())
 			.ok_or_else(|| ArithmeticError::Overflow.into())
+	}
+
+	// Updates the dispute fee after retrieving the latest token price from oracle.
+	pub(super) fn update_dispute_fee() -> DispatchResult {
+		let Some((value, _)) = Self::get_data_before(
+			T::TokenPriceQueryId::get(),
+			Self::now().saturating_sub(12 * HOURS),
+		) else {
+			return Err(Error::<T>::InvalidPrice.into());
+		};
+		let Ok(token_price) = T::ValueConverter::convert(value.into_inner()) else {
+			return Err(Error::<T>::InvalidPrice.into());
+		};
+		let token_price = token_price.into();
+		ensure!(
+			token_price >= 10u128.pow(16).into() && token_price < 10u128.pow(24).into(),
+			Error::<T>::InvalidPrice
+		);
+		let dispute_fee = Self::calculate_dispute_fee(token_price);
+		<DisputeFee<T>>::set(dispute_fee);
+		Self::deposit_event(Event::NewDisputeFee { dispute_fee });
+		Ok(())
 	}
 
 	/// Updates accumulated staking rewards per staked token.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,14 +193,14 @@ pub mod pallet {
 		#[pallet::constant]
 		type StakingTokenPriceQueryId: Get<QueryId>;
 
+		/// Staking token to local token 'SpotPrice' query identifier, used for updating dispute fee.
+		#[pallet::constant]
+		type StakingToLocalTokenPriceQueryId: Get<QueryId>;
+
 		/// The on-chain time provider.
 		type Time: UnixTime;
 
 		type Token: Inspect<Self::AccountId, Balance = Self::Balance> + Transfer<Self::AccountId>;
-
-		/// Staking token to local token 'SpotPrice' query identifier, used for updating dispute fee.
-		#[pallet::constant]
-		type TokenPriceQueryId: Get<QueryId>;
 
 		/// Frequency of stake amount updates.
 		#[pallet::constant]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub mod pallet {
 			+ Into<result::Result<Origin, <Self as Config>::RuntimeOrigin>>;
 
 		/// The units in which we record balances.
-		type Balance: Balance + From<u64> + Into<U256>;
+		type Balance: Balance + From<Timestamp> + From<u128> + Into<U256>;
 
 		/// The number of decimals used by the balance unit.
 		#[pallet::constant]
@@ -112,6 +112,10 @@ pub mod pallet {
 
 		/// Origin that handles dispute resolution (governance).
 		type GovernanceOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
+
+		/// Initial staking token to local token 'SpotPrice' (i.e. TRB:UNIT with 18 decimals).
+		#[pallet::constant]
+		type InitialTokenPrice: Get<u128>;
 
 		/// The maximum number of timestamps per claim.
 		#[pallet::constant]
@@ -194,6 +198,10 @@ pub mod pallet {
 
 		type Token: Inspect<Self::AccountId, Balance = Self::Balance> + Transfer<Self::AccountId>;
 
+		/// Staking token to local token 'SpotPrice' query identifier, used for updating dispute fee.
+		#[pallet::constant]
+		type TokenPriceQueryId: Get<QueryId>;
+
 		/// Frequency of stake amount updates.
 		#[pallet::constant]
 		type UpdateStakeAmountInterval: Get<Timestamp>;
@@ -240,10 +248,11 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn accumulated_reward_per_share)]
 	pub(super) type AccumulatedRewardPerShare<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
-	/// Mapping of query identifiers to a report.
+	/// A timestamp at which the stake amount was last updated.
 	#[pallet::storage]
 	#[pallet::getter(fn last_stake_amount_update)]
 	pub(super) type LastStakeAmountUpdate<T> = StorageValue<_, Timestamp, ValueQuery>;
+	/// Mapping of query identifiers to a report.
 	#[pallet::storage]
 	pub(super) type Reports<T> = StorageMap<_, Identity, QueryId, ReportOf<T>>;
 	/// Total staking rewards released per second.
@@ -279,26 +288,45 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(super) type ToWithdraw<T> = StorageValue<_, Tributes, ValueQuery>;
 	// Governance
+	/// The latest dispute fee.
+	#[pallet::storage]
+	pub(super) type DisputeFee<T> = StorageValue<_, BalanceOf<T>, ValueQuery, InitialDisputeFee<T>>;
+	/// Mapping of reporter accounts to dispute identifiers.
 	#[pallet::storage]
 	pub(super) type DisputeIdsByReporter<T> =
 		StorageDoubleMap<_, Blake2_128Concat, AccountIdOf<T>, Identity, DisputeId, ()>;
+	/// Mapping of dispute identifiers to the details of the dispute.
 	#[pallet::storage]
 	pub(super) type DisputeInfo<T> = StorageMap<_, Identity, DisputeId, DisputeOf<T>>;
+	/// A timestamp at which the dispute fee was last updated.
+	#[pallet::storage]
+	#[pallet::getter(fn last_dispute_fee_update)]
+	pub(super) type LastDisputeFeeUpdate<T> = StorageValue<_, Timestamp, ValueQuery>;
+	/// Mapping of a query identifier to the number of corresponding open disputes.
 	#[pallet::storage]
 	pub(super) type OpenDisputesOnId<T> = StorageMap<_, Identity, QueryId, u128>;
+	/// Total number of votes initiated.
 	#[pallet::storage]
 	pub(super) type VoteCount<T> = StorageValue<_, u128, ValueQuery>;
+	/// Mapping of dispute identifiers to the details of the vote round.
 	#[pallet::storage]
 	pub(super) type VoteInfo<T> =
 		StorageDoubleMap<_, Identity, DisputeId, Twox64Concat, u8, VoteOf<T>>;
+	/// Mapping of dispute identifiers to the number of vote rounds.
 	#[pallet::storage]
 	pub(super) type VoteRounds<T> = StorageMap<_, Identity, DisputeId, u8, ValueQuery>;
+	/// Mapping of addresses to the number of votes they have cast.
 	#[pallet::storage]
 	pub(super) type VoteTallyByAddress<T> =
 		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, u128, ValueQuery>;
 	// Query Data
 	#[pallet::storage]
 	pub(super) type QueryData<T> = StorageMap<_, Identity, QueryId, QueryDataOf<T>>;
+
+	#[pallet::type_value]
+	pub fn InitialDisputeFee<T: Config>() -> BalanceOf<T> {
+		<Pallet<T>>::calculate_dispute_fee(T::InitialTokenPrice::get())
+	}
 
 	#[pallet::type_value]
 	pub fn MinimumStakeAmount<T: Config>() -> Tributes {
@@ -376,6 +404,8 @@ pub mod pallet {
 			timestamp: Timestamp,
 			reporter: AccountIdOf<T>,
 		},
+		/// Emitted when the dispute fee has changed.
+		NewDisputeFee { dispute_fee: BalanceOf<T> },
 		/// Emitted when an address casts their vote.
 		Voted { dispute_id: DisputeId, supports: Option<bool>, voter: AccountIdOf<T> },
 		/// Emitted when all casting for a vote is tallied.
@@ -456,6 +486,7 @@ pub mod pallet {
 		InsufficientStake,
 		/// Nonce must match the timestamp index.
 		InvalidNonce,
+		/// Invalid token price.
 		InvalidPrice,
 		/// Invalid staking token price.
 		InvalidStakingTokenPrice,
@@ -477,7 +508,6 @@ pub mod pallet {
 		// Governance
 		/// Voter has already voted.
 		AlreadyVoted,
-		DisputeFeeCalculationError,
 		/// Dispute must be started within reporting lock time.
 		DisputeReportingPeriodExpired,
 		/// New dispute round must be started within a day.
@@ -526,16 +556,23 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(_n: T::BlockNumber) -> Weight {
-			// Update stake amount
+			// update stake amount/dispute fee
 			const MIN_INTERVAL: Timestamp = 12 * HOURS;
 			let update_interval = T::UpdateStakeAmountInterval::get();
 			if update_interval > Zero::zero() {
 				let timestamp = Self::now();
-				if timestamp >=
-					<LastStakeAmountUpdate<T>>::get() + update_interval.max(MIN_INTERVAL) &&
+				let interval = update_interval.max(MIN_INTERVAL);
+				// update stake amount
+				if timestamp >= <LastStakeAmountUpdate<T>>::get() + interval &&
 					Pallet::<T>::do_update_stake_amount().is_ok()
 				{
-					<LastStakeAmountUpdate<T>>::set(timestamp)
+					<LastStakeAmountUpdate<T>>::set(timestamp);
+				}
+				// update dispute fee
+				if timestamp >= <LastDisputeFeeUpdate<T>>::get() + interval &&
+					Pallet::<T>::update_dispute_fee().is_ok()
+				{
+					<LastDisputeFeeUpdate<T>>::set(timestamp);
 				}
 			}
 
@@ -1059,7 +1096,8 @@ pub mod pallet {
 		#[pallet::call_index(8)]
 		pub fn update_stake_amount(origin: OriginFor<T>) -> DispatchResult {
 			ensure_signed(origin)?;
-			Self::do_update_stake_amount()
+			Self::do_update_stake_amount()?;
+			Self::update_dispute_fee() // todo: should an error here fail the whole tx?
 		}
 
 		/// Initialises a dispute/vote in the system.
@@ -1109,7 +1147,7 @@ pub mod pallet {
 				vote_round,
 				start_date: Self::now(),
 				block_number: frame_system::Pallet::<T>::block_number(),
-				fee: Self::get_dispute_fee().ok_or(Error::<T>::DisputeFeeCalculationError)?,
+				fee: Self::get_dispute_fee(),
 				tally_date: 0,
 				users: Tally::default(),
 				reporters: Tally::default(),

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -131,7 +131,7 @@ impl tellor::Config for Test {
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;
-	type InitialTokenPrice = ConstU128<{ 5 * 10u128.pow(18) }>;
+	type InitialDisputeFee = ConstU128<{ 50 * 10u128.pow(12) }>;
 	type MaxClaimTimestamps = ConstU32<10>;
 	type MaxFeedsPerQuery = ConstU32<10>;
 	type MaxFundedFeeds = ConstU32<10>;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -40,7 +40,7 @@ use std::{
 use xcm::latest::prelude::*;
 
 pub(crate) type AccountId = u128; // u64 is not enough to hold bytes used to generate sub accounts
-type Balance = u64;
+type Balance = u128;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -80,7 +80,7 @@ impl system::Config for Test {
 	type DbWeight = ();
 	type Version = ();
 	type PalletInfo = PalletInfo;
-	type AccountData = pallet_balances::AccountData<u64>;
+	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
@@ -93,7 +93,7 @@ impl pallet_balances::Config for Test {
 	type Balance = Balance;
 	type DustRemoval = ();
 	type RuntimeEvent = RuntimeEvent;
-	type ExistentialDeposit = ConstU64<1>;
+	type ExistentialDeposit = ConstU128<1>;
 	type AccountStore = System;
 	type WeightInfo = ();
 	type MaxLocks = ();
@@ -131,6 +131,7 @@ impl tellor::Config for Test {
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;
+	type InitialTokenPrice = ConstU128<{ 5 * 10u128.pow(18) }>;
 	type MaxClaimTimestamps = ConstU32<10>;
 	type MaxFeedsPerQuery = ConstU32<10>;
 	type MaxFundedFeeds = ConstU32<10>;
@@ -153,6 +154,7 @@ impl tellor::Config for Test {
 	type StakingTokenPriceQueryId = StakingTokenPriceQueryId;
 	type Time = Timestamp;
 	type Token = Balances;
+	type TokenPriceQueryId = ();
 	type UpdateStakeAmountInterval = ConstU64<{ 12 * HOURS }>;
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;

--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -2066,24 +2066,26 @@ fn get_reward_amount() {
 
 		// query rewards
 		let fee: u16 = Fee::get();
-		let mut expected_reward = token(1) + token(1) * (timestamp_1 - timestamp_0);
-		expected_reward = expected_reward - (expected_reward * fee as u64 / (1_000)); // fee
+		let mut expected_reward = token(1) + token(1) * (timestamp_1 - timestamp_0) as Balance;
+		expected_reward = expected_reward - (expected_reward * fee as u128 / (1_000)); // fee
 		let mut reward_sum = expected_reward;
 		assert_eq!(
 			Tellor::get_reward_amount(feed_id, query_id, vec![timestamp_1]),
 			expected_reward
 		);
 
-		expected_reward = token(1) + token(1) * (timestamp_2 - (timestamp_0 + INTERVAL * 1));
-		expected_reward = expected_reward - (expected_reward * fee as u64 / (1_000)); // fee
+		expected_reward =
+			token(1) + token(1) * (timestamp_2 - (timestamp_0 + INTERVAL * 1)) as Balance;
+		expected_reward = expected_reward - (expected_reward * fee as u128 / (1_000)); // fee
 		reward_sum += expected_reward;
 		assert_eq!(
 			Tellor::get_reward_amount(feed_id, query_id, vec![timestamp_2]),
 			expected_reward
 		);
 
-		expected_reward = token(1) + token(1) * (timestamp_3 - (timestamp_0 + INTERVAL * 2));
-		expected_reward = expected_reward - (expected_reward * fee as u64 / (1_000)); // fee
+		expected_reward =
+			token(1) + token(1) * (timestamp_3 - (timestamp_0 + INTERVAL * 2)) as Balance;
+		expected_reward = expected_reward - (expected_reward * fee as u128 / (1_000)); // fee
 		reward_sum += expected_reward;
 		assert_eq!(
 			Tellor::get_reward_amount(feed_id, query_id, vec![timestamp_3]),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -24,7 +24,7 @@ use crate::{
 		ValueOf,
 	},
 	xcm::{ethereum_xcm, gas_to_weight, weigh, DbWeight},
-	Event, Origin, StakeAmount,
+	Event, Origin,
 };
 use ethabi::{Bytes, Token, Uint};
 use frame_support::{

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -110,7 +110,7 @@ fn spot_price(asset: impl Into<String>, currency: impl Into<String>) -> Bytes {
 
 fn token(amount: impl Into<f64>) -> Balance {
 	// test parachain token
-	(amount.into() * unit() as f64) as u64
+	(amount.into() * unit() as f64) as Balance
 }
 
 fn uint_value(value: impl Into<Uint>) -> ValueOf<Test> {

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -1304,7 +1304,7 @@ fn get_total_time_based_rewards_balance() {
 	todo!()
 }
 
-const REWARD_RATE_TARGET: u64 = 60 * 60 * 24 * 30; // 30 days
+const REWARD_RATE_TARGET: Balance = 60 * 60 * 24 * 30; // 30 days
 
 #[test]
 fn add_staking_rewards() {
@@ -1574,6 +1574,16 @@ fn get_data_before() {
 			Some((uint_value(150), timestamp_1))
 		);
 	});
+}
+
+#[test]
+fn update_dispute_fee() {
+	todo!()
+}
+
+#[test]
+fn update_dispute_fee_via_hook() {
+	todo!()
 }
 
 #[test]
@@ -2101,7 +2111,7 @@ fn update_stake_and_pay_rewards() {
 				assert_eq!(Tellor::time_of_last_allocation(), timestamp);
 				assert_eq!(Tellor::reward_rate(), expected_reward_rate);
 				let expected_accumulated_reward_per_share =
-					(timestamp - timestamp_0) * expected_reward_rate / 10;
+					(timestamp - timestamp_0) as Balance * expected_reward_rate / 10;
 				let expected_balance = U256ToBalance::convert(
 					U256::from(token(10)) * U256::from(expected_accumulated_reward_per_share) /
 						U256::from(token(1)),
@@ -2137,7 +2147,7 @@ fn update_stake_and_pay_rewards() {
 				// check conditions after updating rewards
 				assert_eq!(Tellor::time_of_last_allocation(), timestamp);
 				assert_eq!(Tellor::reward_rate(), expected_reward_rate);
-				let expected_accumulated_reward_per_share = ((timestamp - timestamp_1) *
+				let expected_accumulated_reward_per_share = ((timestamp - timestamp_1) as Balance *
 					expected_reward_rate / 10) +
 					expected_accumulated_reward_per_share;
 				assert_eq!(Balances::free_balance(1), expected_balance);
@@ -2172,7 +2182,7 @@ fn update_stake_and_pay_rewards() {
 			// check conditions after updating rewards
 			assert_eq!(Tellor::time_of_last_allocation(), timestamp);
 			assert_eq!(Tellor::reward_rate(), expected_reward_rate);
-			let expected_accumulated_reward_per_share = ((timestamp - timestamp_2) *
+			let expected_accumulated_reward_per_share = ((timestamp - timestamp_2) as Balance *
 				expected_reward_rate /
 				10) + expected_accumulated_reward_per_share;
 			let expected_balance = expected_balance +

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -1577,16 +1577,6 @@ fn get_data_before() {
 }
 
 #[test]
-fn update_dispute_fee() {
-	todo!()
-}
-
-#[test]
-fn update_dispute_fee_via_hook() {
-	todo!()
-}
-
-#[test]
 fn update_stake_amount() {
 	let query_data: QueryDataOf<Test> = spot_price("trb", "gbp").try_into().unwrap();
 	let query_id = keccak_256(query_data.as_ref()).into();


### PR DESCRIPTION
`pallet`
- adds `InitialDisputeFee` and `StakingToLocalTokenPriceQueryId` config items for defining initial dispute fee as well as `query_id` for ongoing updates of dispute fee, based on TRB:OCP token price
- adds `calculate_dispute_fee()` function to calculate dispute fee based on stake amount and supplied price
- adds `update_dispute_fee()` for updating the `DisputeFee` storage item with latest value based on orcle price.
  - only persists and emits `NewDisputeFee` event if value has actually changed
- updates `update_stake_amount` and `on_initialize` hook to update dispute fee along with stake amount, ensuring both complete successfully for state to be updated.
  - hook uses storage transaction to ensure stake amount and dispute fee updated together
- adds/updates tests to ensure that dispute fee and stake amount are updated together both via dispatchable function and hook

`runtime-api`
- restores return type of `get_dispute_fee()` to `Balance` 

closes #17 