### PR TITLE
fix: report vote tallied

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1149,6 +1149,7 @@ impl<T: Config> Pallet<T> {
 		)?;
 		Self::deposit_event(Event::VoteTallied {
 			dispute_id,
+			result,
 			initiator,
 			reporter: <DisputeInfo<T>>::get(dispute_id)
 				.ok_or(Error::<T>::InvalidDispute)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1521,20 +1521,15 @@ pub mod pallet {
 			Self::tally_votes(dispute_id, result)
 		}
 
-		/// Reports the result of a dispute.
+		/// Reports the execution of a vote.
 		///
 		/// - `dispute_id`: The identifier of the dispute.
-		/// - `result`: The result of the dispute.
 		#[pallet::call_index(16)]
-		pub fn report_vote_executed(
-			origin: OriginFor<T>,
-			dispute_id: DisputeId,
-			result: VoteResult,
-		) -> DispatchResult {
+		pub fn report_vote_executed(origin: OriginFor<T>, dispute_id: DisputeId) -> DispatchResult {
 			// ensure origin is governance controller contract
 			T::GovernanceOrigin::ensure_origin(origin)?;
 			// execute vote
-			Self::execute_vote(dispute_id, result)
+			Self::execute_vote(dispute_id)
 		}
 
 		/// Deregisters the parachain from the Tellor controller contracts.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,12 @@ pub mod pallet {
 		/// Emitted when an address casts their vote.
 		Voted { dispute_id: DisputeId, supports: Option<bool>, voter: AccountIdOf<T> },
 		/// Emitted when all casting for a vote is tallied.
-		VoteTallied { dispute_id: DisputeId, initiator: AccountIdOf<T>, reporter: AccountIdOf<T> },
+		VoteTallied {
+			dispute_id: DisputeId,
+			result: VoteResult,
+			initiator: AccountIdOf<T>,
+			reporter: AccountIdOf<T>,
+		},
 		/// Emitted when a vote is executed.
 		VoteExecuted { dispute_id: DisputeId, result: VoteResult },
 

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -457,7 +457,7 @@ fn execute_vote() {
 				MINIMUM_STAKE_AMOUNT.into(),
 				Address::random()
 			));
-			assert_noop!(Tellor::execute_vote(H256::random(), result), Error::InvalidDispute);
+			assert_noop!(Tellor::execute_vote(H256::random()), Error::InvalidDispute);
 			// dispute id must be valid
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter_1),
@@ -506,27 +506,27 @@ fn execute_vote() {
 				"dispute fee paid should be correct"
 			); // uses static rate for now
 
-			assert_noop!(Tellor::execute_vote(H256::random(), result), Error::InvalidDispute); // dispute id must exist
-			assert_noop!(Tellor::execute_vote(dispute_id, result), Error::VoteNotTallied); // vote must be tallied
+			assert_noop!(Tellor::execute_vote(H256::random()), Error::InvalidDispute); // dispute id must exist
+			assert_noop!(Tellor::execute_vote(dispute_id), Error::VoteNotTallied); // vote must be tallied
 			(timestamp_1, dispute_id)
 		});
 
 		// Tally votes after vote duration
 		with_block_after(86_400 * 2, || {
 			assert_ok!(Tellor::tally_votes(dispute_1, result));
-			assert_noop!(Tellor::execute_vote(dispute_1, result), Error::TallyDisputePeriodActive);
+			assert_noop!(Tellor::execute_vote(dispute_1), Error::TallyDisputePeriodActive);
 			// a day must pass before execution
 		});
 
 		// Execute after tally dispute period
 		let (timestamp_2, dispute_2) = with_block_after(86_400 * 2, || {
 			let previous_balance = Balances::free_balance(&dispute_reporter);
-			assert_ok!(Tellor::execute_vote(dispute_1, result));
+			assert_ok!(Tellor::execute_vote(dispute_1));
 			let dispute_fee = Tellor::get_vote_info(dispute_1, 1).unwrap().fee;
 
 			assert_eq!(previous_balance + dispute_fee, Balances::free_balance(&dispute_reporter));
 
-			assert_noop!(Tellor::execute_vote(dispute_1, result), Error::VoteAlreadyExecuted);
+			assert_noop!(Tellor::execute_vote(dispute_1), Error::VoteAlreadyExecuted);
 			// vote already executed
 			assert_noop!(
 				Tellor::begin_dispute(
@@ -580,19 +580,19 @@ fn execute_vote() {
 
 		with_block_after(86_400 * 2, || {
 			assert_eq!(Tellor::get_vote_rounds(dispute_2), 2);
-			assert_noop!(Tellor::execute_vote(dispute_2, result), Error::VoteNotTallied);
+			assert_noop!(Tellor::execute_vote(dispute_2), Error::VoteNotTallied);
 			// vote round must be tallied
 		});
 
 		with_block_after(86_400 * 2, || {
 			assert_ok!(Tellor::tally_votes(dispute_2, result));
-			assert_noop!(Tellor::execute_vote(dispute_2, result), Error::TallyDisputePeriodActive);
+			assert_noop!(Tellor::execute_vote(dispute_2), Error::TallyDisputePeriodActive);
 			// must wait longer
 		});
 
 		with_block_after(86_400, || {
 			let previous_balance = Balances::free_balance(&dispute_reporter);
-			assert_ok!(Tellor::execute_vote(dispute_2, result));
+			assert_ok!(Tellor::execute_vote(dispute_2));
 			let first_round_fee = Tellor::get_vote_info(dispute_2, 1).unwrap().fee;
 			let second_round_fee = Tellor::get_vote_info(dispute_2, 2).unwrap().fee;
 			assert_eq!(
@@ -933,7 +933,7 @@ fn get_disputes_by_reporter() {
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id));
 		});
 
 		assert_eq!(
@@ -1012,7 +1012,7 @@ fn get_open_disputes_on_id() {
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id));
 		});
 
 		assert_eq!(Tellor::get_open_disputes_on_id(query_id), 1);
@@ -1063,7 +1063,7 @@ fn get_vote_count() {
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id));
 			assert_eq!(
 				Tellor::get_vote_count(),
 				1,
@@ -1132,7 +1132,7 @@ fn get_vote_info() {
 		});
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id));
 			let vote = Tellor::get_vote_info(dispute_id, 1).unwrap();
 			let parachain_id: u32 = ParachainId::get();
 			assert_eq!(
@@ -1354,7 +1354,7 @@ fn get_tips_by_address() {
 
 		// Execute vote after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::execute_vote(dispute_id, VoteResult::Passed));
+			assert_ok!(Tellor::execute_vote(dispute_id));
 			assert_eq!(
 				Tellor::get_vote_info(dispute_id, 1).unwrap().users,
 				Tally::<BalanceOf<Test>> { does_support: token(20), against: 0, invalid_query: 0 },
@@ -1390,11 +1390,7 @@ fn invalid_dispute() {
 		let dispute_id = with_block(|| {
 			let dispute_id = dispute_id(PARA_ID, query_id, now());
 			assert_noop!(
-				Tellor::report_vote_executed(
-					RuntimeOrigin::signed(reporter),
-					dispute_id,
-					VoteResult::Invalid
-				),
+				Tellor::report_vote_executed(RuntimeOrigin::signed(reporter), dispute_id),
 				BadOrigin
 			);
 
@@ -1406,13 +1402,9 @@ fn invalid_dispute() {
 			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Invalid));
 		});
 
-		// Report invalid dispute after tally dispute period
+		// Report invalid dispute executed after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::report_vote_executed(
-				Origin::Governance.into(),
-				dispute_id,
-				VoteResult::Invalid
-			));
+			assert_ok!(Tellor::report_vote_executed(Origin::Governance.into(), dispute_id));
 
 			// validate updated balance of dispute initiator
 			assert_eq!(Balances::free_balance(reporter), balance_before_begin_dispute);
@@ -1437,11 +1429,7 @@ fn slash_dispute_initiator() {
 		let dispute_id = with_block(|| {
 			let dispute_id = dispute_id(PARA_ID, query_id, now());
 			assert_noop!(
-				Tellor::report_vote_executed(
-					RuntimeOrigin::signed(reporter),
-					dispute_id,
-					VoteResult::Failed
-				),
+				Tellor::report_vote_executed(RuntimeOrigin::signed(reporter), dispute_id),
 				BadOrigin
 			);
 
@@ -1485,13 +1473,9 @@ fn slash_dispute_initiator() {
 			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Failed));
 		});
 
-		// Report invalid dispute after tally dispute period
+		// Report failed dispute executed after tally dispute period
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::report_vote_executed(
-				Origin::Governance.into(),
-				dispute_id,
-				VoteResult::Failed
-			));
+			assert_ok!(Tellor::report_vote_executed(Origin::Governance.into(), dispute_id));
 
 			// validate slashed balance of dispute initiator
 			let vote_info = Tellor::get_vote_info(dispute_id, 1).unwrap();

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -18,7 +18,7 @@ use super::*;
 use crate::{
 	constants::REPORTING_LOCK,
 	types::{Nonce, QueryId, Timestamp},
-	Config,
+	Config, VoteResult,
 };
 use frame_support::{
 	assert_noop, assert_ok,
@@ -322,7 +322,7 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id, 1));
+			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Passed));
 		});
 
 		// Report slash after tally dispute period
@@ -362,7 +362,7 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id, 1));
+			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Passed));
 		});
 
 		// Report slash after tally dispute period
@@ -397,7 +397,7 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id, 1));
+			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Passed));
 		});
 
 		// Report slash after tally dispute period
@@ -452,7 +452,7 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id, 1));
+			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Passed));
 		});
 
 		// Report slash after tally dispute period

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -322,7 +322,11 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Passed));
+			assert_ok!(Tellor::report_vote_tallied(
+				Origin::Governance.into(),
+				dispute_id,
+				VoteResult::Passed
+			));
 		});
 
 		// Report slash after tally dispute period
@@ -362,7 +366,11 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Passed));
+			assert_ok!(Tellor::report_vote_tallied(
+				Origin::Governance.into(),
+				dispute_id,
+				VoteResult::Passed
+			));
 		});
 
 		// Report slash after tally dispute period
@@ -397,7 +405,11 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Passed));
+			assert_ok!(Tellor::report_vote_tallied(
+				Origin::Governance.into(),
+				dispute_id,
+				VoteResult::Passed
+			));
 		});
 
 		// Report slash after tally dispute period
@@ -452,7 +464,11 @@ fn slash_reporter() {
 
 		// Tally votes after vote duration
 		with_block_after(86_400, || {
-			assert_ok!(Tellor::tally_votes(dispute_id, VoteResult::Passed));
+			assert_ok!(Tellor::report_vote_tallied(
+				Origin::Governance.into(),
+				dispute_id,
+				VoteResult::Passed
+			));
 		});
 
 		// Report slash after tally dispute period


### PR DESCRIPTION
- adds `report_vote_tallied` dispatchable function, taking `dispute_id` and `result` and calling internal `tally_votes` function
  - ensures the vote has not already been executed when tallying
- adds missing `result` to `VoteTallied` event
- adds check to `begin_dispute` ensure that previous round has not been executed when starting a new round
- removes `result` parameter from `report_vote_executed` dispatchable function and internal `execute_vote` function, as result set on vote within tally call
- safe math
- updates tests accordingly

Closes #53 