### PR TITLE
fix: expose time periods

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -779,3 +779,12 @@ fn state_call_encoding() {
 	call(ORACLE, "get_block_number_by_timestamp", &(query_id, timestamp).encode());
 	call(ORACLE, "get_current_value", &query_id.encode());
 }
+
+#[test]
+fn constants() {
+	// Ensures certain constants are publicly available for usage within runtime config
+	const MINUTES: Timestamp = tellor::MINUTES;
+	const HOURS: Timestamp = tellor::HOURS;
+	const DAYS: Timestamp = tellor::DAYS;
+	const WEEKS: Timestamp = tellor::WEEKS;
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,10 +16,10 @@
 
 use crate::types::Timestamp;
 
-const MINUTES: Timestamp = 60;
-pub(crate) const HOURS: Timestamp = 60 * MINUTES;
-pub(crate) const DAYS: Timestamp = 24 * HOURS;
-pub(crate) const WEEKS: Timestamp = 7 * DAYS;
+pub const MINUTES: Timestamp = 60;
+pub const HOURS: Timestamp = 60 * MINUTES;
+pub const DAYS: Timestamp = 24 * HOURS;
+pub const WEEKS: Timestamp = 7 * DAYS;
 
 /// Base amount of time before a reporter is able to submit a value again.
 pub(crate) const REPORTING_LOCK: Timestamp = 12 * HOURS;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use crate::constants::{DAYS, HOURS, REPORTING_LOCK, WEEKS};
+use crate::constants::REPORTING_LOCK;
 pub use crate::xcm::{ContractLocation, LocationToAccount, LocationToOrigin};
 use codec::Encode;
+pub use constants::{DAYS, HOURS, MINUTES, WEEKS};
 use frame_support::{
 	dispatch::{DispatchError, DispatchResult},
 	ensure,


### PR DESCRIPTION
Ensures certain constants are publicly available for usage within runtime config.