### PR TITLE
refactor: optimise storage hashers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,18 +289,18 @@ pub mod pallet {
 	// Governance
 	#[pallet::storage]
 	pub(super) type DisputeIdsByReporter<T> =
-		StorageDoubleMap<_, Blake2_128Concat, AccountIdOf<T>, Blake2_128Concat, DisputeId, ()>;
+		StorageDoubleMap<_, Blake2_128Concat, AccountIdOf<T>, Identity, DisputeId, ()>;
 	#[pallet::storage]
-	pub(super) type DisputeInfo<T> = StorageMap<_, Blake2_128Concat, DisputeId, DisputeOf<T>>;
+	pub(super) type DisputeInfo<T> = StorageMap<_, Identity, DisputeId, DisputeOf<T>>;
 	#[pallet::storage]
 	pub(super) type OpenDisputesOnId<T> = StorageMap<_, Blake2_128Concat, QueryId, u128>;
 	#[pallet::storage]
 	pub(super) type VoteCount<T> = StorageValue<_, u128, ValueQuery>;
 	#[pallet::storage]
 	pub(super) type VoteInfo<T> =
-		StorageDoubleMap<_, Blake2_128Concat, DisputeId, Blake2_128Concat, u8, VoteOf<T>>;
+		StorageDoubleMap<_, Identity, DisputeId, Blake2_128Concat, u8, VoteOf<T>>;
 	#[pallet::storage]
-	pub(super) type VoteRounds<T> = StorageMap<_, Blake2_128Concat, DisputeId, u8, ValueQuery>;
+	pub(super) type VoteRounds<T> = StorageMap<_, Identity, DisputeId, u8, ValueQuery>;
 	#[pallet::storage]
 	pub(super) type VoteTallyByAddress<T> =
 		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, u128, ValueQuery>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,15 +213,11 @@ pub mod pallet {
 
 	// AutoPay
 	#[pallet::storage]
-	pub(super) type CurrentFeeds<T> = StorageMap<
-		_,
-		Blake2_128Concat,
-		QueryId,
-		BoundedVec<FeedId, <T as Config>::MaxFeedsPerQuery>,
-	>;
+	pub(super) type CurrentFeeds<T> =
+		StorageMap<_, Identity, QueryId, BoundedVec<FeedId, <T as Config>::MaxFeedsPerQuery>>;
 	#[pallet::storage]
 	pub(super) type DataFeeds<T> =
-		StorageDoubleMap<_, Blake2_128Concat, QueryId, Blake2_128Concat, FeedId, FeedOf<T>>;
+		StorageDoubleMap<_, Identity, QueryId, Blake2_128Concat, FeedId, FeedOf<T>>;
 	#[pallet::storage]
 	pub(super) type FeedsWithFunding<T> =
 		StorageValue<_, BoundedVec<FeedId, <T as Config>::MaxFundedFeeds>, ValueQuery>;
@@ -232,14 +228,10 @@ pub mod pallet {
 		StorageValue<_, BoundedVec<QueryId, <T as Config>::MaxFundedFeeds>, ValueQuery>;
 	#[pallet::storage]
 	#[pallet::getter(fn query_ids_with_funding_index)]
-	pub(super) type QueryIdsWithFundingIndex<T> = StorageMap<_, Blake2_128Concat, QueryId, u32>;
+	pub(super) type QueryIdsWithFundingIndex<T> = StorageMap<_, Identity, QueryId, u32>;
 	#[pallet::storage]
-	pub(super) type Tips<T> = StorageMap<
-		_,
-		Blake2_128Concat,
-		QueryId,
-		BoundedVec<TipOf<T>, <T as Config>::MaxTipsPerQuery>,
-	>;
+	pub(super) type Tips<T> =
+		StorageMap<_, Identity, QueryId, BoundedVec<TipOf<T>, <T as Config>::MaxTipsPerQuery>>;
 	#[pallet::storage]
 	pub(super) type UserTipsTotal<T> =
 		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, BalanceOf<T>, ValueQuery>;
@@ -253,7 +245,7 @@ pub mod pallet {
 	#[pallet::getter(fn last_stake_amount_update)]
 	pub(super) type LastStakeAmountUpdate<T> = StorageValue<_, Timestamp, ValueQuery>;
 	#[pallet::storage]
-	pub(super) type Reports<T> = StorageMap<_, Blake2_128Concat, QueryId, ReportOf<T>>;
+	pub(super) type Reports<T> = StorageMap<_, Identity, QueryId, ReportOf<T>>;
 	/// Total staking rewards released per second.
 	#[pallet::storage]
 	#[pallet::getter(fn reward_rate)]
@@ -293,7 +285,7 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(super) type DisputeInfo<T> = StorageMap<_, Identity, DisputeId, DisputeOf<T>>;
 	#[pallet::storage]
-	pub(super) type OpenDisputesOnId<T> = StorageMap<_, Blake2_128Concat, QueryId, u128>;
+	pub(super) type OpenDisputesOnId<T> = StorageMap<_, Identity, QueryId, u128>;
 	#[pallet::storage]
 	pub(super) type VoteCount<T> = StorageValue<_, u128, ValueQuery>;
 	#[pallet::storage]
@@ -306,7 +298,7 @@ pub mod pallet {
 		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, u128, ValueQuery>;
 	// Query Data
 	#[pallet::storage]
-	pub(super) type QueryData<T> = StorageMap<_, Blake2_128Concat, QueryId, QueryDataOf<T>>;
+	pub(super) type QueryData<T> = StorageMap<_, Identity, QueryId, QueryDataOf<T>>;
 
 	#[pallet::type_value]
 	pub fn MinimumStakeAmount<T: Config>() -> Tributes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ pub mod pallet {
 	pub(super) type VoteCount<T> = StorageValue<_, u128, ValueQuery>;
 	#[pallet::storage]
 	pub(super) type VoteInfo<T> =
-		StorageDoubleMap<_, Identity, DisputeId, Blake2_128Concat, u8, VoteOf<T>>;
+		StorageDoubleMap<_, Identity, DisputeId, Twox64Concat, u8, VoteOf<T>>;
 	#[pallet::storage]
 	pub(super) type VoteRounds<T> = StorageMap<_, Identity, DisputeId, u8, ValueQuery>;
 	#[pallet::storage]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,12 +217,12 @@ pub mod pallet {
 		StorageMap<_, Identity, QueryId, BoundedVec<FeedId, <T as Config>::MaxFeedsPerQuery>>;
 	#[pallet::storage]
 	pub(super) type DataFeeds<T> =
-		StorageDoubleMap<_, Identity, QueryId, Blake2_128Concat, FeedId, FeedOf<T>>;
+		StorageDoubleMap<_, Identity, QueryId, Identity, FeedId, FeedOf<T>>;
 	#[pallet::storage]
 	pub(super) type FeedsWithFunding<T> =
 		StorageValue<_, BoundedVec<FeedId, <T as Config>::MaxFundedFeeds>, ValueQuery>;
 	#[pallet::storage]
-	pub(super) type QueryIdFromDataFeedId<T> = StorageMap<_, Blake2_128Concat, FeedId, QueryId>;
+	pub(super) type QueryIdFromDataFeedId<T> = StorageMap<_, Identity, FeedId, QueryId>;
 	#[pallet::storage]
 	pub(super) type QueryIdsWithFunding<T> =
 		StorageValue<_, BoundedVec<QueryId, <T as Config>::MaxFundedFeeds>, ValueQuery>;


### PR DESCRIPTION
- uses `Identity` hasher for: 
  - `dispute_id` as hashed internally using `Keccak256`, with only 1/3 hash inputs controlled by caller (`query_id`)
  - `query_id` as it is either verified by `Keccak256`hashing corresponding `query_data` parameter or by checking against existing state (which in turn was verified).
  - `feed_id` as created by `keccak256` hashing data including `query_id`, which in turn is a `keccak256` hash. Other accesses first verify `feed_id` exists before mutating.
- uses `TwoX` hasher for `vote_round` as not directly controlled by caller and requires increasing dispute fee to be paid for each round

**Note:** A careful review is required, along with consideration of the effects of these optimisations, so please take your time with this one. More information at https://docs.substrate.io/build/runtime-storage/#hashing-algorithms

Closes #25 