### PR TITLE
build: use ethabi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+ethabi = { version = "18.0", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 
 # Substrate
@@ -29,7 +30,6 @@ xcm = { git = "https://github.com/paritytech/polkadot", default-features = false
 xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
 
 [dev-dependencies]
-ethabi = { version = "18.0.0", default-features = false }
 once_cell = "1"
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
 pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }

--- a/src/contracts/governance.rs
+++ b/src/contracts/governance.rs
@@ -24,16 +24,17 @@ pub(crate) fn begin_parachain_dispute(
 	dispute_initiator: H160,
 	slash_amount: impl Into<U256>,
 ) -> Vec<u8> {
-	const FUNCTION: [u8; 4] = [29, 93, 54, 159];
-
-	Call::new(&FUNCTION)
-		.fixed_bytes(query_id)
-		.uint(timestamp)
-		.bytes(value)
-		.address(disputed_reporter)
-		.address(dispute_initiator)
-		.uint(slash_amount)
-		.encode()
+	call(
+		&[29, 93, 54, 159],
+		encode(&vec![
+			Token::FixedBytes(query_id.into()),
+			Token::Uint(timestamp.into()),
+			Token::Bytes(value.into()),
+			Token::Address(disputed_reporter),
+			Token::Address(dispute_initiator),
+			Token::Uint(slash_amount.into()),
+		]),
+	)
 }
 
 pub(crate) fn vote(
@@ -45,17 +46,18 @@ pub(crate) fn vote(
 	total_reports_against: impl Into<U256>,
 	total_reports_invalid: impl Into<U256>,
 ) -> Vec<u8> {
-	const FUNCTION: [u8; 4] = [61, 181, 167, 166];
-
-	Call::new(&FUNCTION)
-		.fixed_bytes(dispute_id)
-		.uint(total_tips_for)
-		.uint(total_tips_against)
-		.uint(total_tips_invalid)
-		.uint(total_reports_for)
-		.uint(total_reports_against)
-		.uint(total_reports_invalid)
-		.encode()
+	call(
+		&[61, 181, 167, 166],
+		encode(&vec![
+			Token::FixedBytes(dispute_id.into()),
+			Token::Uint(total_tips_for.into()),
+			Token::Uint(total_tips_against.into()),
+			Token::Uint(total_tips_invalid.into()),
+			Token::Uint(total_reports_for.into()),
+			Token::Uint(total_reports_against.into()),
+			Token::Uint(total_reports_invalid.into()),
+		]),
+	)
 }
 
 #[cfg(test)]
@@ -160,7 +162,7 @@ mod tests {
 		let para_id = 3000;
 		let query_id = keccak_256("my_query".as_bytes());
 		let timestamp = 1675711956967u64;
-		let dispute_id = keccak_256(&ethabi::encode(&vec![
+		let dispute_id = keccak_256(&encode(&vec![
 			Token::Uint(para_id.into()),
 			Token::FixedBytes(query_id.into()).into(),
 			Token::Uint(timestamp.into()),

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -15,101 +15,20 @@
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::types::ParaId;
+pub(crate) use ethabi::{encode, Token};
 use sp_core::{H160, U256};
 use sp_std::{vec, vec::Vec};
+
+pub(crate) type Abi = ethabi::Token;
 
 pub(crate) mod governance;
 pub(crate) mod registry;
 pub(crate) mod staking;
 
-pub(crate) type Abi<'a> = Call<'a>;
-
-pub(crate) struct Call<'a> {
-	function: Vec<u8>,
-	parameters: Vec<Parameter<'a>>,
-}
-
-impl<'a> Call<'a> {
-	fn new(function: &[u8; 4]) -> Self {
-		Call { function: function.to_vec(), parameters: Vec::new() }
-	}
-
-	pub(crate) fn default() -> Self {
-		Call { function: Vec::new(), parameters: Vec::new() }
-	}
-
-	fn address(mut self, address: H160) -> Self {
-		let mut encoded = [0u8; 32];
-		encoded[12..].copy_from_slice(address.as_fixed_bytes());
-		self.parameters.push(Parameter::Static(encoded));
-		self
-	}
-
-	fn bytes(mut self, bytes: &'a [u8]) -> Self {
-		self.parameters.push(Parameter::Dynamic(DynamicParameter::Bytes(bytes)));
-		self
-	}
-
-	pub(crate) fn fixed_bytes(mut self, bytes: &[u8]) -> Self {
-		let mut encoded = [0u8; 32];
-		encoded.copy_from_slice(bytes);
-		self.parameters.push(Parameter::Static(encoded));
-		self
-	}
-
-	pub(crate) fn uint(mut self, value: impl Into<U256>) -> Self {
-		let mut encoded = [0u8; 32];
-		value.into().to_big_endian(&mut encoded);
-		self.parameters.push(Parameter::Static(encoded));
-		self
-	}
-
-	pub(crate) fn encode(mut self) -> Vec<u8> {
-		let mut buffer = [0u8; 32];
-
-		// Add head parts: https://docs.soliditylang.org/en/latest/abi-spec.html#function-selector-and-argument-encoding
-		for parameter in &self.parameters {
-			match parameter {
-				Parameter::Static(parameter) => self.function.extend(parameter),
-				Parameter::Dynamic(parameter) => match parameter {
-					// https://docs.soliditylang.org/en/latest/abi-spec.html#use-of-dynamic-types
-					DynamicParameter::Bytes(_) => {
-						// offset in bytes to start of data area
-						U256::from(self.parameters.len() * 32).to_big_endian(&mut buffer);
-						self.function.extend(buffer);
-					},
-				},
-			}
-		}
-
-		// Add dynamic payloads
-		for parameter in self.parameters {
-			if let Parameter::Dynamic(parameter) = parameter {
-				match parameter {
-					DynamicParameter::Bytes(parameter) => {
-						// Define length
-						U256::from(parameter.len()).to_big_endian(&mut buffer);
-						self.function.extend(buffer);
-
-						// Add data, padding to 32 bytes
-						self.function.extend(parameter.iter());
-						self.function.extend(vec![0; ((parameter.len() + 31) / 32) + 1]);
-					},
-				}
-			}
-		}
-
-		self.function
-	}
-}
-
-enum Parameter<'a> {
-	Static([u8; 32]),
-	Dynamic(DynamicParameter<'a>),
-}
-
-enum DynamicParameter<'a> {
-	Bytes(&'a [u8]),
+fn call(function: &[u8; 4], mut parameters: Vec<u8>) -> Vec<u8> {
+	let mut encoded = function.to_vec();
+	encoded.append(parameters.as_mut());
+	encoded
 }
 
 pub(crate) mod gas_limits {
@@ -122,40 +41,10 @@ pub(crate) mod gas_limits {
 
 #[cfg(test)]
 pub(crate) mod tests {
-	use super::Call;
-	use crate::types::Address;
-	use ethabi::{encode, Param, ParamType, Token};
-	use sp_core::{keccak_256, U256};
+	use ethabi::{Param, ParamType};
 
 	// Helper for creating a parameter
 	pub(crate) fn param(name: &str, kind: ParamType) -> Param {
 		Param { name: name.to_string(), kind, internal_type: None }
-	}
-
-	#[test]
-	fn encodes_address() {
-		let address = Address::random();
-		assert_eq!(
-			encode(&[Token::Address(address)])[..],
-			Call::new(&[0; 4]).address(address).encode()[4..]
-		);
-	}
-
-	#[test]
-	fn encodes_uint() {
-		let value = 12345u128;
-		assert_eq!(
-			encode(&[Token::Uint(U256::from(value))])[..],
-			Call::new(&[0; 4]).uint(value).encode()[4..]
-		);
-	}
-
-	#[test]
-	fn encodes_fixed_bytes() {
-		let value = keccak_256(b"hello");
-		assert_eq!(
-			encode(&[Token::FixedBytes(value.to_vec())])[..],
-			Call::new(&[0; 4]).fixed_bytes(&value).encode()[4..]
-		);
 	}
 }

--- a/src/contracts/registry.rs
+++ b/src/contracts/registry.rs
@@ -17,13 +17,14 @@
 use super::*;
 
 pub(crate) fn register(para_id: ParaId, pallet_index: u8) -> Vec<u8> {
-	const FUNCTION: [u8; 4] = [20, 1, 238, 43];
-	Call::new(&FUNCTION).uint(para_id).uint(pallet_index).encode()
+	call(
+		&[20, 1, 238, 43],
+		encode(&vec![Token::Uint(para_id.into()), Token::Uint(pallet_index.into())]),
+	)
 }
 
 pub(crate) fn deregister() -> Vec<u8> {
-	const FUNCTION: [u8; 4] = [175, 245, 237, 177];
-	FUNCTION.to_vec()
+	[175, 245, 237, 177].to_vec()
 }
 
 #[cfg(test)]

--- a/src/contracts/staking.rs
+++ b/src/contracts/staking.rs
@@ -20,8 +20,10 @@ pub(crate) fn confirm_parachain_stake_withdraw_request(
 	address: impl Into<H160>,
 	amount: impl Into<U256>,
 ) -> Vec<u8> {
-	const FUNCTION: [u8; 4] = [116, 48, 87, 226];
-	Call::new(&FUNCTION).address(address.into()).uint(amount.into()).encode()
+	call(
+		&[116, 48, 87, 226],
+		encode(&vec![Token::Address(address.into()), Token::Uint(amount.into())]),
+	)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The existing abi encoding requirements were rather basic so I simply mirrored some of the functionality of [ethabi](https://github.com/rust-ethereum/ethabi) to not have to take a non-dev dependency and then verified the simple implementation using the same crate via tests. It seems like to we need to do some slightly more advanced encoding now, so it is probably a good opportunity to replace the simple encoding with something more robust, eliminating a lot of redundant code.

Please can you review the library and ensure that you are happy to take on this dependency before approving. The crate was historically created by Parity I believe, before being turned over to the community. https://github.com/rust-ethereum/ethabi/network/dependents shows the projects dependent on the crate and there are some decently sized names in the Ethereum space using it to some degree.

I noticed [Snowfork](https://github.com/Snowfork/ethabi-decode) and [Centrifuge](https://parachains.info/details/centrifuge) from the Polkadot ecosystem are using it in one of there pallets, but cannot say whether it is live on any network.

