### PR TITLE
refactor: improve value to price conversion

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -131,7 +131,6 @@ impl tellor::Config for Test {
 	type MinimumStakeAmount = ();
 	type PalletId = TellorPalletId;
 	type ParachainId = ();
-	type Price = u32;
 	type RegisterOrigin = frame_system::EnsureRoot<AccountId>;
 	type Registry = ();
 	type StakeAmountCurrencyTarget = ();
@@ -142,7 +141,6 @@ impl tellor::Config for Test {
 	type Time = Time;
 	type Token = Balances;
 	type UpdateStakeAmountInterval = ();
-	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
 	type XcmFeesAsset = XcmFeesAsset;
 	type XcmWeightToAsset = ();
@@ -154,13 +152,6 @@ impl tellor::traits::SendXcm for TestSendXcm {
 		_dest: impl Into<MultiLocation>,
 		_message: Xcm<()>,
 	) -> Result<(), SendError> {
-		todo!()
-	}
-}
-
-pub struct ValueConverter;
-impl Convert<Vec<u8>, Result<u32, sp_runtime::DispatchError>> for ValueConverter {
-	fn convert(a: Vec<u8>) -> Result<u32, sp_runtime::DispatchError> {
 		todo!()
 	}
 }

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use ethabi::{encode, Token};
 use sp_core::{H160, U256};
 use sp_std::{vec, vec::Vec};
 
-pub(crate) type Abi = ethabi::Token;
+pub(crate) type Abi = Token;
 
 pub(crate) mod governance;
 pub(crate) mod registry;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -206,10 +206,12 @@ impl<T: Config> Pallet<T> {
 			Self::get_data_before(query_id, timestamp).unwrap_or_default();
 		let mut price_change = 0; // price change from last value to current value
 		if feed.details.price_threshold != 0 {
+			// v1 is value retrieved at supplied timestamp
 			let v1 = BytesToU256::convert(
 				value_retrieved.expect("value retrieved checked above; qed").into_inner(),
 			)
 			.ok_or(Error::<T>::ValueConversionError)?;
+			// v2 is latest value retrieved BEFORE supplied timestamp
 			let v2 = BytesToU256::convert(value_retrieved_before.into_inner())
 				.ok_or(Error::<T>::ValueConversionError)?;
 			if v2 == U256::zero() {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -24,10 +24,6 @@ use sp_runtime::{
 use sp_std::cmp::Ordering;
 
 impl<T: Config> Pallet<T> {
-	pub(super) fn bytes_to_price(value: ValueOf<T>) -> Result<T::Price, DispatchError> {
-		T::ValueConverter::convert(value.into_inner())
-	}
-
 	/// Calculates the latest dispute fee based on the supplied price.
 	/// # Arguments
 	/// * `price` - The current staking token to local balance price.
@@ -210,19 +206,22 @@ impl<T: Config> Pallet<T> {
 			Self::get_data_before(query_id, timestamp).unwrap_or_default();
 		let mut price_change = 0; // price change from last value to current value
 		if feed.details.price_threshold != 0 {
-			let v1 =
-				Self::bytes_to_price(value_retrieved.expect("value retrieved checked above; qed"))?;
-			let v2 = Self::bytes_to_price(value_retrieved_before)?;
-			if v2 == Zero::zero() {
+			let v1 = BytesToU256::convert(
+				value_retrieved.expect("value retrieved checked above; qed").into_inner(),
+			)
+			.ok_or(Error::<T>::ValueConversionError)?;
+			let v2 = BytesToU256::convert(value_retrieved_before.into_inner())
+				.ok_or(Error::<T>::ValueConversionError)?;
+			if v2 == U256::zero() {
 				price_change = 10_000;
 			} else if v1 >= v2 {
-				price_change = (T::Price::from(10_000u16).saturating_mul(v1.saturating_sub(v2)))
-					.checked_div(&v2)
+				price_change = (U256::from(10_000).saturating_mul(v1.saturating_sub(v2)))
+					.checked_div(v2)
 					.expect("v2 checked against zero above; qed")
 					.saturated_into();
 			} else {
-				price_change = (T::Price::from(10_000u16).saturating_mul(v2.saturating_sub(v1)))
-					.checked_div(&v2)
+				price_change = (U256::from(10_000u16).saturating_mul(v2.saturating_sub(v1)))
+					.checked_div(v2)
 					.expect("v2 checked against zero above; qed")
 					.saturated_into();
 			}
@@ -254,10 +253,9 @@ impl<T: Config> Pallet<T> {
 		) else {
 			return Err(Error::<T>::InvalidStakingTokenPrice.into());
 		};
-		let Ok(staking_token_price) = T::ValueConverter::convert(value.into_inner()) else {
+		let Some(staking_token_price) = BytesToU256::convert(value.into_inner()) else {
 			return Err(Error::<T>::InvalidStakingTokenPrice.into());
 		};
-		let staking_token_price = staking_token_price.into();
 		ensure!(
 			staking_token_price >= 10u128.pow(16).into() &&
 				staking_token_price < 10u128.pow(24).into(),
@@ -1186,10 +1184,9 @@ impl<T: Config> Pallet<T> {
 		) else {
 			return Err(Error::<T>::InvalidPrice.into());
 		};
-		let Ok(token_price) = T::ValueConverter::convert(value.into_inner()) else {
+		let Some(token_price) = BytesToU256::convert(value.into_inner()) else {
 			return Err(Error::<T>::InvalidPrice.into());
 		};
-		let token_price = token_price.into();
 		ensure!(
 			token_price >= 10u128.pow(16).into() && token_price < 10u128.pow(24).into(),
 			Error::<T>::InvalidPrice
@@ -1388,7 +1385,7 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-impl<T: Config> UsingTellor<AccountIdOf<T>, PriceOf<T>> for Pallet<T> {
+impl<T: Config> UsingTellor<AccountIdOf<T>> for Pallet<T> {
 	fn get_data_after(query_id: QueryId, timestamp: Timestamp) -> Option<(Vec<u8>, Timestamp)> {
 		Self::get_index_for_data_after(query_id, timestamp)
 			.and_then(|index| Self::get_timestamp_by_query_id_and_index(query_id, index))
@@ -1445,7 +1442,7 @@ impl<T: Config> UsingTellor<AccountIdOf<T>, PriceOf<T>> for Pallet<T> {
 		Self::retrieve_data(query_id, timestamp).map(|v| v.into_inner())
 	}
 
-	fn value_to_price(value: Vec<u8>) -> Option<PriceOf<T>> {
-		T::ValueConverter::convert(value).ok()
+	fn value_to_price(value: Vec<u8>) -> Option<Price> {
+		BytesToU256::convert(value)
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub mod pallet {
 	use ::xcm::latest::prelude::*;
 	use frame_support::{
 		pallet_prelude::*,
-		sp_runtime::traits::{AtLeast32BitUnsigned, Hash},
+		sp_runtime::traits::Hash,
 		traits::{
 			fungible::{Inspect, Transfer},
 			tokens::Balance,
@@ -174,8 +174,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type ParachainId: Get<ParaId>;
 
-		type Price: AtLeast32BitUnsigned + Copy + Default + Into<U256>;
-
 		/// Origin that manages registration and deregistration from the controller contracts.
 		type RegisterOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 
@@ -210,9 +208,6 @@ pub mod pallet {
 		/// Frequency of stake amount updates.
 		#[pallet::constant]
 		type UpdateStakeAmountInterval: Get<Timestamp>;
-
-		/// Conversion from submitted value (bytes) to a price for price threshold evaluation.
-		type ValueConverter: Convert<Vec<u8>, Result<Self::Price, DispatchError>>;
 
 		/// The sub-system used for sending XCM messages.
 		type Xcm: traits::SendXcm;
@@ -475,6 +470,7 @@ pub mod pallet {
 		TipAlreadyClaimed,
 		/// Tip earned by previous submission.
 		TipAlreadyEarned,
+		/// An error occurred converting an oracle value.
 		ValueConversionError,
 		/// Value disputed.
 		ValueDisputed,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -17,7 +17,6 @@
 use crate as tellor;
 use crate::{
 	constants::HOURS, types::Address, xcm::ContractLocation, EnsureGovernance, EnsureStaking,
-	Error::ValueConversionError,
 };
 use frame_support::{
 	assert_ok, log, parameter_types,
@@ -29,8 +28,7 @@ use once_cell::sync::Lazy;
 use sp_core::{ConstU128, ConstU32, ConstU8, H256};
 use sp_runtime::{
 	testing::Header,
-	traits::{BlakeTwo256, Convert, IdentityLookup},
-	DispatchError,
+	traits::{BlakeTwo256, IdentityLookup},
 };
 use sp_std::cell::RefCell;
 use std::{
@@ -141,12 +139,11 @@ impl tellor::Config for Test {
 	type MaxRewardClaims = ConstU32<10>;
 	type MaxTimestamps = ConstU32<100>;
 	type MaxTipsPerQuery = ConstU32<10>;
-	type MaxValueLength = ConstU32<128>; // Chain may want to store any raw bytes, so ValueConverter needs to handle conversion to price for threshold checks
+	type MaxValueLength = ConstU32<128>; // Chain may want to store any raw bytes, so value conversion needs to handle conversion to price for threshold checks
 	type MaxVotes = ConstU32<10>;
 	type MinimumStakeAmount = MinimumStakeAmount;
 	type PalletId = TellorPalletId;
 	type ParachainId = ParachainId;
-	type Price = u128;
 	type RegisterOrigin = system::EnsureRoot<AccountId>;
 	type Registry = TellorRegistry;
 	type StakeAmountCurrencyTarget = ConstU128<{ 500 * 10u128.pow(18) }>;
@@ -157,21 +154,9 @@ impl tellor::Config for Test {
 	type Time = Timestamp;
 	type Token = Balances;
 	type UpdateStakeAmountInterval = ConstU64<{ 12 * HOURS }>;
-	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;
 	type XcmFeesAsset = XcmFeesAsset;
 	type XcmWeightToAsset = ConstU128<50_000>; // Moonbase Alpha: https://github.com/PureStake/moonbeam/blob/f19ba9de013a1c789425d3b71e8a92d54f2191af/runtime/moonbase/src/lib.rs#L135
-}
-
-pub struct ValueConverter;
-impl Convert<Vec<u8>, Result<u128, DispatchError>> for ValueConverter {
-	fn convert(a: Vec<u8>) -> Result<u128, DispatchError> {
-		// Should be more advanced depending on chain config
-		match a[16..].try_into() {
-			Ok(v) => Ok(u128::from_be_bytes(v)),
-			Err(_) => Err(ValueConversionError::<Test>.into()),
-		}
-	}
 }
 
 thread_local! {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::types::{QueryId, Timestamp};
+use crate::types::{Price, QueryId, Timestamp};
 use sp_std::vec::Vec;
 use xcm::latest::prelude::*;
 
@@ -28,7 +28,7 @@ pub trait SendXcm {
 }
 
 /// This trait helps pallets read data from Tellor
-pub trait UsingTellor<AccountId, Price> {
+pub trait UsingTellor<AccountId> {
 	/// Retrieves the next value for the query identifier after the specified timestamp.
 	/// # Arguments
 	/// * `query_id` - The query identifier to look up the value for.

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,6 +24,7 @@ use sp_runtime::{
 	traits::{Convert, Zero},
 	SaturatedConversion,
 };
+use sp_std::vec::Vec;
 
 pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 /// Address of a reporter on controller chain.
@@ -40,7 +41,7 @@ pub(crate) type FeedOf<T> = autopay::Feed<BalanceOf<T>, <T as Config>::MaxReward
 pub(crate) type FeedDetailsOf<T> = autopay::FeedDetails<BalanceOf<T>>;
 pub(crate) type Nonce = u128;
 pub(crate) type ParaId = u32;
-pub(crate) type PriceOf<T> = <T as Config>::Price;
+pub(crate) type Price = U256;
 pub(crate) type QueryDataOf<T> = BoundedVec<u8, <T as Config>::MaxQueryDataLength>;
 pub type QueryId = H256;
 pub(crate) type ReportOf<T> =
@@ -248,5 +249,13 @@ pub(super) struct U256ToBalance<T>(PhantomData<T>);
 impl<T: Config> Convert<U256, BalanceOf<T>> for U256ToBalance<T> {
 	fn convert(a: U256) -> BalanceOf<T> {
 		a.saturated_into::<u128>().saturated_into()
+	}
+}
+
+pub struct BytesToU256;
+impl Convert<Vec<u8>, Option<U256>> for BytesToU256 {
+	fn convert(a: Vec<u8>) -> Option<U256> {
+		let a: Option<[u8; 32]> = a.try_into().ok();
+		a.map(|a| a.into())
 	}
 }


### PR DESCRIPTION
- removes `Price` and `ValueConverter` config items as price is always `U256` (18 decimals) according to data specs
- `BytesToU256` converter handles conversion, returning `Some(U256)` when provided input vector is expected length otherwise `None`

Closes #70 , #20.