### PR TITLE
refactor: rename token to asset

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -112,6 +112,7 @@ parameter_types! {
 impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
+	type Asset = Balances;
 	type Balance = Balance;
 	type Decimals = ();
 	type Fee = ();
@@ -140,7 +141,6 @@ impl tellor::Config for Test {
 	type StakingTokenPriceQueryId = ();
 	type StakingToLocalTokenPriceQueryId = ();
 	type Time = Time;
-	type Token = Balances;
 	type UpdateStakeAmountInterval = ();
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -115,9 +115,9 @@ impl<T: Config> Pallet<T> {
 		amount: BalanceOf<T>,
 	) -> DispatchResult {
 		let staking_rewards = Self::staking_rewards();
-		T::Token::transfer(source, &staking_rewards, amount, false)?;
+		T::Asset::transfer(source, &staking_rewards, amount, false)?;
 		Self::update_rewards()?;
-		let staking_rewards_balance = T::Token::balance(&staking_rewards).into();
+		let staking_rewards_balance = T::Asset::balance(&staking_rewards).into();
 		// update reward rate = real staking rewards balance / 30 days
 		let total_stake_amount = Self::convert(<TotalStakeAmount<T>>::get())?;
 		<RewardRate<T>>::set(U256ToBalance::<T>::convert(
@@ -157,7 +157,7 @@ impl<T: Config> Pallet<T> {
 
 		ensure!(amount > Zero::zero(), Error::<T>::InvalidAmount);
 		feed.details.balance.saturating_accrue(amount);
-		T::Token::transfer(&feed_funder, &Self::tips(), amount, true)?;
+		T::Asset::transfer(&feed_funder, &Self::tips(), amount, true)?;
 		// Add to array of feeds with funding
 		if feed.details.feeds_with_funding_index == 0 && feed.details.balance > Zero::zero() {
 			let index = <FeedsWithFunding<T>>::try_mutate(
@@ -340,7 +340,7 @@ impl<T: Config> Pallet<T> {
 								// If vote failed, transfer the dispute fee to disputed reporter
 								VoteResult::Failed => &dispute.disputed_reporter,
 							};
-							T::Token::transfer(dispute_fees, dest, dispute_fee, false)?;
+							T::Asset::transfer(dispute_fees, dest, dispute_fee, false)?;
 						}
 						Ok(result)
 					},
@@ -1242,7 +1242,7 @@ impl<T: Config> Pallet<T> {
 		.ok_or(ArithmeticError::DivisionByZero)?
 		.checked_sub(total_reward_debt)
 		.ok_or(ArithmeticError::Underflow)?;
-		let staking_rewards_balance = T::Token::balance(&Self::staking_rewards()).into();
+		let staking_rewards_balance = T::Asset::balance(&Self::staking_rewards()).into();
 		if accumulated_reward >= staking_rewards_balance {
 			// if staking rewards run out, calculate remaining reward per staked token and set
 			// RewardRate to 0
@@ -1321,7 +1321,7 @@ impl<T: Config> Pallet<T> {
 					pending_reward = temp_pending_reward;
 				}
 			}
-			T::Token::transfer(&staking_rewards, staker, pending_reward, true)?;
+			T::Asset::transfer(&staking_rewards, staker, pending_reward, true)?;
 			<TotalRewardDebt<T>>::mutate(|debt| {
 				*debt = debt.saturating_sub(stake_info.reward_debt)
 			});
@@ -1366,7 +1366,7 @@ impl<T: Config> Pallet<T> {
 		<RewardRate<T>>::try_mutate(|reward_rate| -> DispatchResult {
 			if *reward_rate == Zero::zero() {
 				*reward_rate = U256ToBalance::<T>::convert(
-					T::Token::balance(&staking_rewards)
+					T::Asset::balance(&staking_rewards)
 						.into()
 						.checked_sub(
 							accumulated_reward_per_share

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,9 @@ pub mod pallet {
 		type RuntimeOrigin: From<<Self as frame_system::Config>::RuntimeOrigin>
 			+ Into<result::Result<Origin, <Self as Config>::RuntimeOrigin>>;
 
+		/// The fungible asset used for tips, dispute fees and staking rewards.
+		type Asset: Inspect<Self::AccountId, Balance = Self::Balance> + Transfer<Self::AccountId>;
+
 		/// The units in which we record balances.
 		type Balance: Balance + From<Timestamp> + From<u128> + Into<U256>;
 
@@ -204,8 +207,6 @@ pub mod pallet {
 
 		/// The on-chain time provider.
 		type Time: UnixTime;
-
-		type Token: Inspect<Self::AccountId, Balance = Self::Balance> + Transfer<Self::AccountId>;
 
 		/// Frequency of stake amount updates.
 		#[pallet::constant]
@@ -636,7 +637,7 @@ pub mod pallet {
 				.checked_div(&1000u16.into())
 				.ok_or(Error::<T>::FeeCalculationError)?;
 			let tips = &Self::tips();
-			T::Token::transfer(
+			T::Asset::transfer(
 				tips,
 				&reporter,
 				// todo: safe math
@@ -764,7 +765,7 @@ pub mod pallet {
 				.checked_div(&1000u16.into())
 				.ok_or(Error::<T>::FeeCalculationError)?;
 			let tips = &Self::tips();
-			T::Token::transfer(
+			T::Asset::transfer(
 				tips,
 				&reporter,
 				// todo: safe math
@@ -947,7 +948,7 @@ pub mod pallet {
 				)?;
 				<QueryIdsWithFundingIndex<T>>::set(query_id, Some(len));
 			}
-			T::Token::transfer(&tipper, &Self::tips(), amount, true)?;
+			T::Asset::transfer(&tipper, &Self::tips(), amount, true)?;
 			<UserTipsTotal<T>>::mutate(&tipper, |total| total.saturating_accrue(amount));
 			Self::deposit_event(Event::TipAdded { query_id, amount, query_data, tipper });
 			Ok(())
@@ -1208,7 +1209,7 @@ pub mod pallet {
 			}
 			<VoteCount<T>>::mutate(|count| count.saturating_inc());
 			let dispute_fee = vote.fee;
-			T::Token::transfer(&dispute_initiator, &Self::dispute_fees(), dispute_fee, false)?;
+			T::Asset::transfer(&dispute_initiator, &Self::dispute_fees(), dispute_fee, false)?;
 			<VoteInfo<T>>::insert(dispute_id, vote_round, vote);
 			<DisputeInfo<T>>::insert(dispute_id, &dispute);
 			Self::deposit_event(Event::NewDispute {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -127,6 +127,7 @@ parameter_types! {
 impl tellor::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeOrigin = RuntimeOrigin;
+	type Asset = Balances;
 	type Balance = Balance;
 	type Decimals = ConstU8<12>;
 	type Fee = ConstU16<10>; // 1%
@@ -155,7 +156,6 @@ impl tellor::Config for Test {
 	type StakingTokenPriceQueryId = StakingTokenPriceQueryId;
 	type StakingToLocalTokenPriceQueryId = StakingToLocalTokenPriceQueryId;
 	type Time = Timestamp;
-	type Token = Balances;
 	type UpdateStakeAmountInterval = ConstU64<{ 12 * HOURS }>;
 	type ValueConverter = ValueConverter;
 	type Xcm = TestSendXcm;


### PR DESCRIPTION
Better aligns with the descriptions of the `Inspect` and `Transfer` traits used as bounds for the `Asset` config item, namely 'fungible asset'.