### PR TITLE
feat: add custom weight and update registration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ xcm = { git = "https://github.com/paritytech/polkadot", default-features = false
 xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
 
 [dev-dependencies]
+hex = "0.4"
 once_cell = "1"
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
 pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -115,6 +115,7 @@ impl tellor::Config for Test {
 	type Asset = Balances;
 	type Balance = Balance;
 	type Decimals = ();
+	type RemoteXCMWeightToFee = ();
 	type Fee = ();
 	type Governance = ();
 	type GovernanceOrigin = EnsureGovernance;
@@ -144,6 +145,7 @@ impl tellor::Config for Test {
 	type Xcm = TestSendXcm;
 	type XcmFeesAsset = XcmFeesAsset;
 	type XcmWeightToAsset = ();
+	type RemoteXcmFeeLocation = ();
 }
 pub struct TestSendXcm;
 impl tellor::traits::SendXcm for TestSendXcm {

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -107,6 +107,7 @@ impl pallet_timestamp::Config for Test {
 }
 parameter_types! {
 	pub const TellorPalletId: PalletId = PalletId(*b"py/tellr");
+	pub const FeeLocation: Junctions = Junctions::Here;
 	pub const XcmFeesAsset: AssetId = AssetId::Abstract(vec![]);
 }
 impl tellor::Config for Test {
@@ -115,8 +116,8 @@ impl tellor::Config for Test {
 	type Asset = Balances;
 	type Balance = Balance;
 	type Decimals = ();
-	type RemoteXCMWeightToFee = ();
 	type Fee = ();
+	type FeeLocation = FeeLocation;
 	type Governance = ();
 	type GovernanceOrigin = EnsureGovernance;
 	type InitialDisputeFee = ();
@@ -142,10 +143,10 @@ impl tellor::Config for Test {
 	type StakingToLocalTokenPriceQueryId = ();
 	type Time = Time;
 	type UpdateStakeAmountInterval = ();
+	type WeightToFee = ();
 	type Xcm = TestSendXcm;
 	type XcmFeesAsset = XcmFeesAsset;
 	type XcmWeightToAsset = ();
-	type RemoteXcmFeeLocation = ();
 }
 pub struct TestSendXcm;
 impl tellor::traits::SendXcm for TestSendXcm {

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -36,7 +36,7 @@ pub(crate) mod gas_limits {
 	pub(crate) const BEGIN_PARACHAIN_DISPUTE: u64 = 600_000;
 	pub(crate) const CONFIRM_STAKING_WITHDRAW_REQUEST: u64 = 60_000;
 	pub(crate) const DEREGISTER: u64 = 30_000;
-	pub(crate) const REGISTER: u64 = 95_000;
+	pub(crate) const REGISTER: u64 = 250_000;
 	pub(crate) const VOTE: u64 = 150_000;
 }
 

--- a/src/contracts/registry.rs
+++ b/src/contracts/registry.rs
@@ -23,16 +23,14 @@ pub(crate) fn register(
 	para_id: ParaId,
 	pallet_index: u8,
 	weight_to_fee: u128,
-	decimals: u8,
 	fee_location: MultiLocation,
 ) -> Vec<u8> {
 	call(
-		&[160, 223, 109, 227],
+		&[116, 99, 167, 98],
 		encode(&[
 			Token::Uint(para_id.into()),
 			Token::Uint(pallet_index.into()),
 			Token::Uint(weight_to_fee.into()),
-			Token::Uint(decimals.into()),
 			Token::Tuple(vec![
 				Token::Uint(fee_location.parents.into()),
 				Token::Array(
@@ -127,7 +125,6 @@ mod tests {
 				param("_paraId", ParamType::Uint(32)),
 				param("_palletIndex", ParamType::Uint(8)),
 				param("_weightToFee", ParamType::Uint(256)),
-				param("_decimals", ParamType::Uint(8)),
 				param(
 					"_feeLocation",
 					ParamType::Tuple(vec![
@@ -155,7 +152,6 @@ mod tests {
 		let para_id = 3000;
 		let pallet_index = 3;
 		let weight_to_fee = 10_000;
-		let decimals = 12;
 		let fee_location = MultiLocation::new(1, X1(Parachain(3000))); // fee location for execution on this parachain, from context of evm parachain
 
 		assert_eq!(
@@ -164,14 +160,13 @@ mod tests {
 					Token::Uint(para_id.into()),
 					Token::Uint(pallet_index.into()),
 					Token::Uint(weight_to_fee.into()),
-					Token::Uint(decimals.into()),
 					Token::Tuple(vec![
 						Token::Uint(1.into()),
 						Token::Array(vec![Token::Bytes(encode_junction(Parachain(3000)))])
 					])
 				])
 				.unwrap()[..],
-			super::register(para_id, pallet_index, weight_to_fee, decimals, fee_location)[..]
+			super::register(para_id, pallet_index, weight_to_fee, fee_location)[..]
 		)
 	}
 

--- a/src/contracts/registry.rs
+++ b/src/contracts/registry.rs
@@ -16,25 +16,94 @@
 
 use super::*;
 use codec::Encode;
-use xcm::v1::MultiLocation;
+use ethabi::Token;
+use xcm::latest::{Junction, MultiLocation, NetworkId};
 
 pub(crate) fn register(
 	para_id: ParaId,
 	pallet_index: u8,
 	weight_to_fee: u128,
 	decimals: u8,
-	fee_location: Vec<u8>,
+	fee_location: MultiLocation,
 ) -> Vec<u8> {
 	call(
-		&[144, 40, 35, 210],
+		&[160, 223, 109, 227],
 		encode(&[
 			Token::Uint(para_id.into()),
 			Token::Uint(pallet_index.into()),
 			Token::Uint(weight_to_fee.into()),
 			Token::Uint(decimals.into()),
-			Token::Bytes(fee_location.encode()),
+			Token::Tuple(vec![
+				Token::Uint(fee_location.parents.into()),
+				Token::Array(
+					fee_location
+						.interior
+						.into_iter()
+						.map(|j| Token::Bytes(encode_junction(j)))
+						.collect(),
+				),
+			]),
 		]),
 	)
+}
+
+fn encode_junction(junction: Junction) -> Vec<u8> {
+	// Based on https://github.com/PureStake/moonbeam/blob/7f85ea4d5f6feb9e1f37355c8269ffebc533dd51/precompiles/utils/src/data/xcm.rs#L173
+	match junction {
+		Junction::Parachain(para_id) => {
+			let mut encoded = vec![0];
+			encoded.extend(para_id.to_be_bytes());
+			encoded
+		},
+		Junction::AccountId32 { network, id } => {
+			let mut encoded = vec![1];
+			encoded.extend(id);
+			encoded.extend(encode_network_id(network));
+			encoded
+		},
+		Junction::AccountIndex64 { network, index } => {
+			let mut encoded = vec![2];
+			encoded.extend(index.to_be_bytes());
+			encoded.extend(encode_network_id(network));
+			encoded
+		},
+		Junction::AccountKey20 { network, key } => {
+			let mut encoded = vec![3];
+			encoded.extend(key);
+			encoded.extend(network.encode());
+			encoded
+		},
+		Junction::PalletInstance(i) => {
+			let mut encoded = vec![4];
+			encoded.extend(i.to_be_bytes());
+			encoded
+		},
+		Junction::GeneralIndex(i) => {
+			let mut encoded = vec![5];
+			encoded.extend(i.to_be_bytes());
+			encoded
+		},
+		Junction::GeneralKey(key) => {
+			let mut encoded = vec![6];
+			encoded.extend(key.into_inner());
+			encoded
+		},
+		Junction::OnlyChild => vec![7],
+		_ => unreachable!("Junction::Plurality not supported yet"),
+	}
+}
+
+fn encode_network_id(network_id: NetworkId) -> Vec<u8> {
+	match network_id {
+		NetworkId::Any => vec![0],
+		NetworkId::Named(name) => {
+			let mut encoded = vec![1];
+			encoded.append(name.into_inner().as_mut());
+			encoded
+		},
+		NetworkId::Polkadot => vec![2],
+		NetworkId::Kusama => vec![3],
+	}
 }
 
 pub(crate) fn deregister() -> Vec<u8> {
@@ -44,22 +113,28 @@ pub(crate) fn deregister() -> Vec<u8> {
 #[cfg(test)]
 mod tests {
 	use super::super::tests::*;
-	use codec::Encode;
+	use crate::contracts::registry::encode_junction;
 	use ethabi::{Function, ParamType, Token};
-	use frame_support::traits::DefensiveMax;
+	use sp_core::{bounded::WeakBoundedVec, bytes::from_hex, H160, H256};
 	use xcm::latest::prelude::*;
 
 	#[allow(deprecated)]
 	fn register() -> Function {
-		// register(uint32,uint8)
+		// register(uint32,uint8,uint256,uint8,(uint8,bytes[]))
 		Function {
 			name: "register".to_string(),
 			inputs: vec![
 				param("_paraId", ParamType::Uint(32)),
 				param("_palletIndex", ParamType::Uint(8)),
-				param("_weightToFee", ParamType::Uint(128)),
+				param("_weightToFee", ParamType::Uint(256)),
 				param("_decimals", ParamType::Uint(8)),
-				param("_feeLocation", ParamType::Bytes),
+				param(
+					"_feeLocation",
+					ParamType::Tuple(vec![
+						ParamType::Uint(8),                           // parents
+						ParamType::Array(Box::new(ParamType::Bytes)), // interior
+					]),
+				),
 			],
 			outputs: vec![],
 			constant: None,
@@ -79,9 +154,9 @@ mod tests {
 	fn encodes_register_call() {
 		let para_id = 3000;
 		let pallet_index = 3;
-		let weight_to_fee = 10000;
-		let decimals = 10;
-		let fee_location = MultiLocation { parents: 0, interior: X1(PalletInstance(3)) };
+		let weight_to_fee = 10_000;
+		let decimals = 12;
+		let fee_location = MultiLocation::new(1, X1(Parachain(3000))); // fee location for execution on this parachain, from context of evm parachain
 
 		assert_eq!(
 			register()
@@ -90,11 +165,13 @@ mod tests {
 					Token::Uint(pallet_index.into()),
 					Token::Uint(weight_to_fee.into()),
 					Token::Uint(decimals.into()),
-					Token::Bytes(fee_location.encode())
+					Token::Tuple(vec![
+						Token::Uint(1.into()),
+						Token::Array(vec![Token::Bytes(encode_junction(Parachain(3000)))])
+					])
 				])
 				.unwrap()[..],
-			super::register(para_id, pallet_index, weight_to_fee, decimals, fee_location.encode())
-				[..]
+			super::register(para_id, pallet_index, weight_to_fee, decimals, fee_location)[..]
 		)
 	}
 
@@ -121,5 +198,40 @@ mod tests {
 	#[test]
 	fn encodes_deregister_call() {
 		assert_eq!(deregister().encode_input(&vec![]).unwrap()[..], super::deregister()[..])
+	}
+
+	#[test]
+	fn encodes_junctions() {
+		let id = H256::random().0;
+		let key = H160::random().0;
+		let x: Vec<(Junction, Vec<u8>)> = vec![
+			(Parachain(2023), from_hex("0x00000007E7").unwrap()),
+			(
+				AccountId32 { network: Any, id },
+				from_hex(&format!("0x01{}00", hex::encode(id))).unwrap(),
+			),
+			(
+				AccountIndex64 { network: Any, index: u64::MAX },
+				from_hex(&format!("0x02{}00", hex::encode(u64::MAX.to_be_bytes()))).unwrap(),
+			),
+			(
+				AccountKey20 { network: Any, key },
+				from_hex(&format!("0x03{}00", hex::encode(key))).unwrap(),
+			),
+			(PalletInstance(3), from_hex("0x0403").unwrap()),
+			(
+				GeneralIndex(u128::MAX),
+				from_hex(&format!("0x05{}", hex::encode(u128::MAX.to_be_bytes()))).unwrap(),
+			),
+			(
+				GeneralKey(WeakBoundedVec::try_from(key.to_vec()).unwrap()),
+				from_hex(&format!("0x06{}", hex::encode(key))).unwrap(),
+			),
+			(OnlyChild, from_hex("0x07").unwrap()),
+		];
+
+		for (source, expected) in x {
+			assert_eq!(super::encode_junction(source), expected);
+		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,7 +612,6 @@ pub mod pallet {
 						T::ParachainId::get(),
 						Pallet::<T>::index() as u8,
 						T::WeightToFee::get(),
-						T::Decimals::get(),
 						<xcm::FeeLocation<T>>::get()?,
 					)
 					.try_into()

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -120,8 +120,7 @@ parameter_types! {
 	pub StakingTokenPriceQueryId: H256 = H256([211,194,112,119,36,198,191,243,89,99,24,187,3,60,229,109,166,126,119,8,208,251,201,107,66,216,126,12,172,199,241,136]);
 	pub StakingToLocalTokenPriceQueryId: H256 = H256([252, 212, 53, 69, 139, 47, 79, 224, 14, 207, 98, 192, 81, 195, 123, 170, 138, 241, 23, 4, 53, 70, 22, 191, 191, 171, 11, 101, 130, 16, 61, 30]);
 	pub XcmFeesAsset : AssetId = AssetId::Concrete(PalletInstance(3).into()); // Balances pallet on EVM parachain
-	pub RemoteXcmFeeLocation : MultiLocation = MultiLocation { parents: 0, interior: X1(PalletInstance(3)) };
-
+	pub FeeLocation : Junctions = Junctions::Here;
 }
 
 impl tellor::Config for Test {
@@ -130,8 +129,8 @@ impl tellor::Config for Test {
 	type Asset = Balances;
 	type Balance = Balance;
 	type Decimals = ConstU8<12>;
-	type RemoteXCMWeightToFee = ConstU128<10000>;
 	type Fee = ConstU16<10>; // 1%
+	type FeeLocation = FeeLocation;
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;
 	type InitialDisputeFee = ConstU128<{ 50 * 10u128.pow(12) }>; // (100 TRB / 10) * 5, where TRB 1:5 OCP
@@ -157,10 +156,10 @@ impl tellor::Config for Test {
 	type StakingToLocalTokenPriceQueryId = StakingToLocalTokenPriceQueryId;
 	type Time = Timestamp;
 	type UpdateStakeAmountInterval = ConstU64<{ 12 * HOURS }>;
+	type WeightToFee = ConstU128<10_000>;
 	type Xcm = TestSendXcm;
 	type XcmFeesAsset = XcmFeesAsset;
-	type XcmWeightToAsset = ConstU128<50_000>;
-	type RemoteXcmFeeLocation = RemoteXcmFeeLocation; // Moonbase Alpha: https://github.com/PureStake/moonbeam/blob/f19ba9de013a1c789425d3b71e8a92d54f2191af/runtime/moonbase/src/lib.rs#L135
+	type XcmWeightToAsset = ConstU128<50_000>; // Moonbase Alpha: https://github.com/PureStake/moonbeam/blob/f19ba9de013a1c789425d3b71e8a92d54f2191af/runtime/moonbase/src/lib.rs#L135
 }
 
 thread_local! {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -120,6 +120,8 @@ parameter_types! {
 	pub StakingTokenPriceQueryId: H256 = H256([211,194,112,119,36,198,191,243,89,99,24,187,3,60,229,109,166,126,119,8,208,251,201,107,66,216,126,12,172,199,241,136]);
 	pub StakingToLocalTokenPriceQueryId: H256 = H256([252, 212, 53, 69, 139, 47, 79, 224, 14, 207, 98, 192, 81, 195, 123, 170, 138, 241, 23, 4, 53, 70, 22, 191, 191, 171, 11, 101, 130, 16, 61, 30]);
 	pub XcmFeesAsset : AssetId = AssetId::Concrete(PalletInstance(3).into()); // Balances pallet on EVM parachain
+	pub RemoteXcmFeeLocation : MultiLocation = MultiLocation { parents: 0, interior: X1(PalletInstance(3)) };
+
 }
 
 impl tellor::Config for Test {
@@ -128,6 +130,7 @@ impl tellor::Config for Test {
 	type Asset = Balances;
 	type Balance = Balance;
 	type Decimals = ConstU8<12>;
+	type RemoteXCMWeightToFee = ConstU128<10000>;
 	type Fee = ConstU16<10>; // 1%
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;
@@ -156,7 +159,8 @@ impl tellor::Config for Test {
 	type UpdateStakeAmountInterval = ConstU64<{ 12 * HOURS }>;
 	type Xcm = TestSendXcm;
 	type XcmFeesAsset = XcmFeesAsset;
-	type XcmWeightToAsset = ConstU128<50_000>; // Moonbase Alpha: https://github.com/PureStake/moonbeam/blob/f19ba9de013a1c789425d3b71e8a92d54f2191af/runtime/moonbase/src/lib.rs#L135
+	type XcmWeightToAsset = ConstU128<50_000>;
+	type RemoteXcmFeeLocation = RemoteXcmFeeLocation; // Moonbase Alpha: https://github.com/PureStake/moonbeam/blob/f19ba9de013a1c789425d3b71e8a92d54f2191af/runtime/moonbase/src/lib.rs#L135
 }
 
 thread_local! {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -218,7 +218,6 @@ fn registers() {
 							PARA_ID,
 							PALLET_INDEX,
 							<Test as crate::Config>::WeightToFee::get(),
-							<Test as crate::Config>::Decimals::get(),
 							crate::xcm::FeeLocation::<Test>::get().unwrap()
 						)
 						.try_into()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -38,7 +38,6 @@ use sp_runtime::{
 };
 use std::convert::Into;
 use xcm::{latest::prelude::*, DoubleEncoded};
-use codec::Encode;
 
 mod autopay;
 mod governance;
@@ -215,10 +214,15 @@ fn registers() {
 				vec![xcm_transact(
 					ethereum_xcm::transact(
 						*REGISTRY,
-						registry::register(PARA_ID, PALLET_INDEX,
-										   <Test as crate::Config>::RemoteXCMWeightToFee::get(),
-										   <Test as crate::Config>::Decimals::get(),
-										   <Test as crate::Config>::RemoteXcmFeeLocation::get().encode()).try_into().unwrap(),
+						registry::register(
+							PARA_ID,
+							PALLET_INDEX,
+							<Test as crate::Config>::WeightToFee::get(),
+							<Test as crate::Config>::Decimals::get(),
+							crate::xcm::FeeLocation::<Test>::get().unwrap()
+						)
+						.try_into()
+						.unwrap(),
 						gas_limits::REGISTER
 					)
 					.into(),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -38,6 +38,7 @@ use sp_runtime::{
 };
 use std::convert::Into;
 use xcm::{latest::prelude::*, DoubleEncoded};
+use codec::Encode;
 
 mod autopay;
 mod governance;
@@ -214,7 +215,10 @@ fn registers() {
 				vec![xcm_transact(
 					ethereum_xcm::transact(
 						*REGISTRY,
-						registry::register(PARA_ID, PALLET_INDEX).try_into().unwrap(),
+						registry::register(PARA_ID, PALLET_INDEX,
+										   <Test as crate::Config>::RemoteXCMWeightToFee::get(),
+										   <Test as crate::Config>::Decimals::get(),
+										   <Test as crate::Config>::RemoteXcmFeeLocation::get().encode()).try_into().unwrap(),
 						gas_limits::REGISTER
 					)
 					.into(),


### PR DESCRIPTION
Based on @pawanbisht62's work and companion to https://github.com/tellor-io/tellor-parachain-contracts/pull/59:
- adds two new config items which allows parachain to configure the `FeeLocation` and `WeightToFee` used when registering the parachain with the contracts. These values are used to calculate the fees (amount and type) to be withdrawn to pay for execution of the call to the pallet on the consumer parachain
- adds `FeeLocation<T> `helper type for converting from config to `MultiLocation`
- encodes the `Junctions` within the `MultiLocation` used to denote the fee_location using Moonbeam's Solidity precompile encoding scheme
- adds weights to the various dispatchable functions, which are then used in the contracts to calculate the weight/fee required
- increases the `REGISTER` gas limit constant due to the additional parameters