### PR TITLE
feat: vote on multiple disputes

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -122,6 +122,7 @@ impl tellor::Config for Test {
 	type GovernanceOrigin = EnsureGovernance;
 	type InitialDisputeFee = ();
 	type MaxClaimTimestamps = ();
+	type MaxDisputeVotes = ();
 	type MaxFeedsPerQuery = ();
 	type MaxFundedFeeds = ();
 	type MaxQueriesPerReporter = ConstU32<100>;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -135,6 +135,7 @@ impl tellor::Config for Test {
 	type GovernanceOrigin = EnsureGovernance;
 	type InitialDisputeFee = ConstU128<{ 50 * 10u128.pow(12) }>; // (100 TRB / 10) * 5, where TRB 1:5 OCP
 	type MaxClaimTimestamps = ConstU32<10>;
+	type MaxDisputeVotes = ConstU32<10>;
 	type MaxFeedsPerQuery = ConstU32<10>;
 	type MaxFundedFeeds = ConstU32<10>;
 	type MaxQueriesPerReporter = ConstU32<10>;


### PR DESCRIPTION
- moves `vote()` implementation to `do_vote()`
- adds `vote_on_multiple_disputes()` dispatchable function, which iterates over bounded votes parameter, calling `do_vote()` for each
- adds `MaxDisputeVotes` config item, for configuring the maximum number of disputes which can be voted on in a single call
- adds vote_on_multiple_disputes() test implementation from source contract tests

Closes #79