### PR TITLE
refactor: only write dispute info on first vote round

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1209,17 +1209,7 @@ pub mod pallet {
 				initiator: dispute_initiator.clone(),
 				voted: BoundedBTreeMap::default(),
 			};
-			// todo: optimise to only write if not already existing
-			let mut dispute = DisputeOf::<T> {
-				query_id,
-				timestamp,
-				value: <ValueOf<T>>::default(),
-				disputed_reporter: Self::get_reporter_by_timestamp(query_id, timestamp)
-					.ok_or(Error::<T>::NoValueExists)?,
-				slashed_amount: <StakeAmount<T>>::get(),
-			};
-			<DisputeIdsByReporter<T>>::insert(&dispute.disputed_reporter, dispute_id, ());
-			if vote_round == 1 {
+			let dispute = if vote_round == 1 {
 				ensure!(
 					Self::now().checked_sub(timestamp).ok_or(ArithmeticError::Underflow)? <
 						REPORTING_LOCK,
@@ -1249,9 +1239,19 @@ pub mod pallet {
 						),
 					)
 					.ok_or(ArithmeticError::Overflow)?;
-				dispute.value =
-					Self::retrieve_data(query_id, timestamp).ok_or(Error::<T>::InvalidTimestamp)?;
+				let dispute = DisputeOf::<T> {
+					query_id,
+					timestamp,
+					value: Self::retrieve_data(query_id, timestamp)
+						.ok_or(Error::<T>::InvalidTimestamp)?,
+					disputed_reporter: Self::get_reporter_by_timestamp(query_id, timestamp)
+						.ok_or(Error::<T>::NoValueExists)?,
+					slashed_amount: <StakeAmount<T>>::get(),
+				};
+				<DisputeIdsByReporter<T>>::insert(&dispute.disputed_reporter, dispute_id, ());
+				<DisputeInfo<T>>::insert(dispute_id, &dispute);
 				Self::remove_value(query_id, timestamp)?;
+				dispute
 			} else {
 				let prev_id = vote_round.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
 				let prev_vote =
@@ -1270,9 +1270,8 @@ pub mod pallet {
 						vote_round.checked_sub(1).ok_or(ArithmeticError::Underflow)?.into(),
 					))
 					.ok_or(ArithmeticError::Overflow)?;
-				dispute.value =
-					<DisputeInfo<T>>::get(dispute_id).ok_or(Error::<T>::InvalidDispute)?.value;
-			}
+				<DisputeInfo<T>>::get(dispute_id).ok_or(Error::<T>::InvalidDispute)?
+			};
 			let stake_amount = U256ToBalance::<T>::convert(Self::convert(<StakeAmount<T>>::get())?);
 			if vote.fee > stake_amount {
 				vote.fee = stake_amount;
@@ -1282,7 +1281,6 @@ pub mod pallet {
 			T::Asset::transfer(&dispute_initiator, &Self::dispute_fees(), dispute_fee, false)?;
 			<PendingVotes<T>>::insert(dispute_id, (vote_round, vote.start_date + (11 * HOURS)));
 			<VoteInfo<T>>::insert(dispute_id, vote_round, vote);
-			<DisputeInfo<T>>::insert(dispute_id, &dispute);
 			Self::deposit_event(Event::NewDispute {
 				dispute_id,
 				query_id,


### PR DESCRIPTION
Updates `begin_dispute()` to only write `Dispute` to `DisputeInfo` storage on the first vote round, as corresponding struct values dont change thereafter. 

Current implementation writes same values on each subsequent vote round for same `query_id` and `timestamp`. This logic is left over from when `dispute_id` was an incrementing integer instead of a `hash(para_id, query_id, timestamp)`.

Closes #81 