### PR TITLE
feat: emit events once xcm sent

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -298,10 +298,18 @@ impl<T: Config> Pallet<T> {
 					),
 					GAS_LIMIT,
 				);
-				Self::send_xcm(governance_contract.para_id, message)?;
+				Self::send_xcm(
+					governance_contract.para_id,
+					message,
+					Event::VoteSent {
+						para_id: governance_contract.para_id,
+						contract_address: governance_contract.address.into(),
+						dispute_id,
+						vote_round,
+					},
+				)?;
 				vote.sent = true;
 				<PendingVotes<T>>::remove(dispute_id);
-				Self::deposit_event(Event::VoteSent { dispute_id, vote_round });
 				Ok(())
 			});
 		}

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -108,7 +108,7 @@ impl pallet_timestamp::Config for Test {
 
 pub(crate) static REGISTRY: Lazy<[u8; 20]> = Lazy::new(|| Address::random().into());
 pub(crate) static GOVERNANCE: Lazy<[u8; 20]> = Lazy::new(|| Address::random().into());
-static STAKING: Lazy<[u8; 20]> = Lazy::new(|| Address::random().into());
+pub(crate) static STAKING: Lazy<[u8; 20]> = Lazy::new(|| Address::random().into());
 
 parameter_types! {
 	pub const MinimumStakeAmount: u128 = 100 * 10u128.pow(18); // 100 TRB

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -84,10 +84,14 @@ fn submit_value_and_begin_dispute(
 	));
 	assert_ok!(Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, now(), None));
 
-	match System::events().last().unwrap().event {
-		RuntimeEvent::Tellor(Event::<Test>::NewDispute { dispute_id, .. }) => dispute_id,
-		_ => panic!(),
-	}
+	System::events()
+		.iter()
+		.filter_map(|e| match e.event {
+			RuntimeEvent::Tellor(Event::<Test>::NewDispute { dispute_id, .. }) => Some(dispute_id),
+			_ => None,
+		})
+		.last()
+		.unwrap()
 }
 
 fn deposit_stake(reporter: AccountIdOf<Test>, amount: impl Into<Tributes>, address: Address) {
@@ -230,7 +234,7 @@ fn registers() {
 				)]
 			);
 			System::assert_last_event(
-				Event::RegistrationAttempted {
+				Event::RegistrationSent {
 					para_id: EVM_PARA_ID,
 					contract_address: (*REGISTRY).into(),
 				}

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -232,6 +232,16 @@ fn request_stake_withdraw() {
 				trb(10),
 				address
 			));
+			System::assert_has_event(
+				Event::StakeWithdrawRequestReported { reporter, amount: trb(10), address }.into(),
+			);
+			System::assert_last_event(
+				Event::StakeWithdrawRequestConfirmationSent {
+					para_id: EVM_PARA_ID,
+					contract_address: (*STAKING).into(),
+				}
+				.into(),
+			);
 			let staker_details = Tellor::get_staker_info(reporter).unwrap();
 			assert_eq!(staker_details.start_date, now());
 			assert_eq!(staker_details.reward_debt, 0);


### PR DESCRIPTION
- adds `event` parameter to `send_xcm`() helper function, ensuring that all xcm sent emits an event once successful
- updates all corresponding events to end with _Sent_
- adds missing event assertions to tests
- uses `assert_has_event` rather than `assert_last_event` for second to last event

Closes #82