### PR TITLE
docs: flag time-based rewards functionality as a backlog item

### DIFF
--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -263,8 +263,6 @@ sp_api::decl_runtime_apis! {
 		/// The total number of current stakers.
 		fn get_total_stakers() -> u128;
 
-		// todo: get_total_time_based_rewards_balance
-
 		/// Returns whether a given value is disputed.
 		/// # Arguments
 		/// * `query_id` - Unique identifier of the data feed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1099,7 +1099,7 @@ pub mod pallet {
 				.map_err(|_| Error::<T>::MaxTimestampsReached)?;
 			<Reports<T>>::insert(query_id, report);
 
-			// todo: Disperse Time Based Reward
+			// backlog: Disperse Time Based Reward
 			// uint256 _reward = ((block.timestamp - timeOfLastNewValue) * timeBasedReward) / 300; //.5 TRB per 5 minutes
 			// uint256 _totalTimeBasedRewardsBalance =
 			// 	token.balanceOf(address(this)) -

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -1303,7 +1303,7 @@ fn retrieve_data() {
 #[ignore]
 fn get_total_time_based_rewards_balance() {
 	// https://github.com/tellor-io/tellorFlex/blob/3b3820f2111ec2813cb51455ef68cf0955c51674/test/functionTests-TellorFlex.js#L533
-	todo!()
+	unimplemented!("currently in backlog")
 }
 
 const REWARD_RATE_TARGET: Balance = 60 * 60 * 24 * 30; // 30 days


### PR DESCRIPTION
Simply removes the 'todo' flags from time-based rewards functionality and labels as 'backlog'. Could alternatively remove completely.

See #11 for more information