### PR TITLE
fix: saturate dispute fees

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub mod pallet {
 	use sp_core::{bounded::BoundedBTreeMap, U256};
 	use sp_runtime::{
 		traits::{CheckedConversion, CheckedSub},
-		ArithmeticError,
+		ArithmeticError, SaturatedConversion,
 	};
 	use sp_std::{prelude::*, result};
 
@@ -1233,19 +1233,15 @@ pub mod pallet {
 					Ok(())
 				})?;
 				// calculate dispute fee based on number of open disputes on query id
-				vote.fee = vote
-					.fee
-					.checked_mul(
-						&<BalanceOf<T>>::from(2u8).saturating_pow(
-							<OpenDisputesOnId<T>>::get(query_id)
-								.ok_or(Error::<T>::InvalidIndex)?
-								.checked_sub(1)
-								.ok_or(ArithmeticError::Underflow)?
-								.checked_into()
-								.ok_or(ArithmeticError::Overflow)?,
-						),
-					)
-					.ok_or(ArithmeticError::Overflow)?;
+				vote.fee = vote.fee.saturating_mul(
+					<BalanceOf<T>>::from(2u8).saturating_pow(
+						<OpenDisputesOnId<T>>::get(query_id)
+							.ok_or(Error::<T>::InvalidIndex)?
+							.checked_sub(1)
+							.expect("open disputes always greater than zero, as set above; qed")
+							.saturated_into(),
+					),
+				);
 				let dispute = DisputeOf::<T> {
 					query_id,
 					timestamp,
@@ -1271,15 +1267,12 @@ pub mod pallet {
 					Error::<T>::DisputeRoundReportingPeriodExpired
 				);
 				ensure!(!prev_vote.executed, Error::<T>::VoteAlreadyExecuted); // Ensure previous round not executed
-				vote.fee = vote
-					.fee
-					.checked_mul(&<BalanceOf<T>>::from(2u8).saturating_pow(
-						vote_round.checked_sub(1).ok_or(ArithmeticError::Underflow)?.into(),
-					))
-					.ok_or(ArithmeticError::Overflow)?;
+				vote.fee = vote.fee.saturating_mul(<BalanceOf<T>>::from(2u8).saturating_pow(
+					vote_round.checked_sub(1).expect("vote round checked above; qed").into(),
+				));
 				<DisputeInfo<T>>::get(dispute_id).ok_or(Error::<T>::InvalidDispute)?
 			};
-			let stake_amount = U256ToBalance::<T>::convert(Self::convert(<StakeAmount<T>>::get())?);
+			let stake_amount = <DisputeFee<T>>::get().saturating_mul(10u8.into());
 			if vote.fee > stake_amount {
 				vote.fee = stake_amount;
 			}

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -141,7 +141,7 @@ impl tellor::Config for Test {
 	type MaxQueriesPerReporter = ConstU32<10>;
 	type MaxQueryDataLength = ConstU32<1000>;
 	type MaxRewardClaims = ConstU32<10>;
-	type MaxTimestamps = ConstU32<100>;
+	type MaxTimestamps = ConstU32<{ 31_536_000 / 6 * 100 }>; // Seconds per year / 6s block time * 100 years
 	type MaxTipsPerQuery = ConstU32<10>;
 	type MaxValueLength = ConstU32<128>; // Chain may want to store any raw bytes, so value conversion needs to handle conversion to price for threshold checks
 	type MaxVotes = ConstU32<10>;


### PR DESCRIPTION
Fixes calculation of dispute fee to saturate into `Balance` type. 

**Note:** even if calculated dispute fee saturates, it is still set to a maximum of the stake amount. 

- updates `begin_dispute` to use `saturating_*` math when calculating dispute fee 
- also corrects stake amount to be calculated as dispute fee * 10, to account for variability of dispute fee in local token in relation to 10% of 100 TRB
- adds `begin_dispute_fee_saturates` and `begin_dispute_round_fee_saturates` tests which ensure at least up to 256 rounds/opens disputes supported
- sets `MaxTimestamps` config value in mock runtime, effectively constraining number of reports per query_id to a max of 100 years

