### PR TITLE
refactor: improve config item name

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -122,11 +122,11 @@ impl tellor::Config for Test {
 	type GovernanceOrigin = EnsureGovernance;
 	type InitialDisputeFee = ();
 	type MaxClaimTimestamps = ();
-	type MaxDisputeVotes = ();
 	type MaxFundedFeeds = ();
 	type MaxQueryDataLength = ();
 	type MaxTipsPerQuery = ();
 	type MaxValueLength = MaxValueLength;
+	type MaxVotes = ();
 	type MinimumStakeAmount = ();
 	type PalletId = TellorPalletId;
 	type ParachainId = ();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,10 +134,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxClaimTimestamps: Get<u32>;
 
-		/// The maximum number of dispute votes per dispatchable call.
-		#[pallet::constant]
-		type MaxDisputeVotes: Get<u32>;
-
 		/// The maximum number of funded feeds.
 		#[pallet::constant]
 		type MaxFundedFeeds: Get<u32>;
@@ -153,6 +149,10 @@ pub mod pallet {
 		/// The maximum length of an individual value submitted to the oracle.
 		#[pallet::constant]
 		type MaxValueLength: Get<u32>;
+
+		/// The maximum number of votes when voting on multiple disputes.
+		#[pallet::constant]
+		type MaxVotes: Get<u32>;
 
 		/// The minimum amount of tokens required to stake.
 		#[pallet::constant]
@@ -1308,7 +1308,7 @@ pub mod pallet {
 		#[pallet::weight(343852000)]
 		pub fn vote_on_multiple_disputes(
 			origin: OriginFor<T>,
-			votes: BoundedVec<(DisputeId, Option<bool>), T::MaxDisputeVotes>,
+			votes: BoundedVec<(DisputeId, Option<bool>), T::MaxVotes>,
 		) -> DispatchResult {
 			let voter = ensure_signed(origin)?;
 			for (dispute_id, supports) in votes {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -135,11 +135,11 @@ impl tellor::Config for Test {
 	type GovernanceOrigin = EnsureGovernance;
 	type InitialDisputeFee = ConstU128<{ 50 * 10u128.pow(12) }>; // (100 TRB / 10) * 5, where TRB 1:5 OCP
 	type MaxClaimTimestamps = ConstU32<10>;
-	type MaxDisputeVotes = ConstU32<10>;
 	type MaxFundedFeeds = ConstU32<10>;
 	type MaxQueryDataLength = ConstU32<1000>;
 	type MaxTipsPerQuery = ConstU32<10>;
 	type MaxValueLength = ConstU32<128>; // Chain may want to store any raw bytes, so value conversion needs to handle conversion to price for threshold checks
+	type MaxVotes = ConstU32<10>;
 	type MinimumStakeAmount = MinimumStakeAmount;
 	type PalletId = TellorPalletId;
 	type ParachainId = ParachainId;


### PR DESCRIPTION
Simple change to improve the name of a config item. It was previously named this way due to MaxVotes already being used for something else, recently removed via storage optimisations.