### PR TITLE
Send extrinsic weights in registration

### DIFF
--- a/src/contracts/registry.rs
+++ b/src/contracts/registry.rs
@@ -15,7 +15,7 @@
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use crate::types::governance::Weights;
+use crate::types::Weights;
 use codec::Encode;
 use ethabi::Token;
 use xcm::latest::{Junction, MultiLocation, NetworkId};
@@ -144,7 +144,7 @@ mod tests {
 	use super::super::tests::*;
 	use crate::{
 		contracts::registry::{encode_junction, encode_network_id},
-		types::governance::Weights,
+		types::Weights,
 	};
 	use ethabi::{Function, ParamType, Token};
 	use sp_core::{bytes::from_hex, H160, H256};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub mod pallet {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	use crate::traits::BenchmarkHelper;
-	use crate::types::governance::Weights;
+	use crate::types::Weights;
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -20,8 +20,8 @@ use crate::{
 	mock,
 	mock::*,
 	types::{
-		governance::Weights, AccountIdOf, Address, BalanceOf, DisputeId, QueryDataOf, QueryId,
-		Timestamp, Tributes, ValueOf,
+		AccountIdOf, Address, BalanceOf, DisputeId, QueryDataOf, QueryId, Timestamp, Tributes,
+		ValueOf, Weights,
 	},
 	weights::WeightInfo,
 	xcm::{ethereum_xcm, gas_to_weight, weigh, DbWeight},

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -20,9 +20,10 @@ use crate::{
 	mock,
 	mock::*,
 	types::{
-		AccountIdOf, Address, BalanceOf, DisputeId, QueryDataOf, QueryId, Timestamp, Tributes,
-		ValueOf,
+		governance::Weights, AccountIdOf, Address, BalanceOf, DisputeId, QueryDataOf, QueryId,
+		Timestamp, Tributes, ValueOf,
 	},
+	weights::WeightInfo,
 	xcm::{ethereum_xcm, gas_to_weight, weigh, DbWeight},
 	Event, Origin,
 };
@@ -213,6 +214,23 @@ fn registers() {
 				assert_noop!(Tellor::register(origin), BadOrigin);
 			}
 
+			let weights = Weights {
+				report_stake_deposited:
+					<Test as crate::Config>::WeightInfo::report_stake_deposited().ref_time(),
+				report_staking_withdraw_request:
+					<Test as crate::Config>::WeightInfo::report_staking_withdraw_request()
+						.ref_time(),
+				report_stake_withdrawn:
+					<Test as crate::Config>::WeightInfo::report_stake_withdrawn().ref_time(),
+				report_vote_tallied: <Test as crate::Config>::WeightInfo::report_vote_tallied()
+					.ref_time(),
+				report_vote_executed: <Test as crate::Config>::WeightInfo::report_vote_executed(
+					u8::MAX.into(),
+				)
+				.ref_time(),
+				report_slash: <Test as crate::Config>::WeightInfo::report_slash().ref_time(),
+			};
+
 			assert_ok!(Tellor::register(RuntimeOrigin::root()));
 			assert_eq!(
 				sent_xcm(),
@@ -223,7 +241,8 @@ fn registers() {
 							PARA_ID,
 							PALLET_INDEX,
 							<Test as crate::Config>::WeightToFee::get(),
-							crate::xcm::FeeLocation::<Test>::get().unwrap()
+							crate::xcm::FeeLocation::<Test>::get().unwrap(),
+							weights.clone()
 						)
 						.try_into()
 						.unwrap(),
@@ -237,6 +256,7 @@ fn registers() {
 				Event::RegistrationSent {
 					para_id: EVM_PARA_ID,
 					contract_address: (*REGISTRY).into(),
+					weights,
 				}
 				.into(),
 			)

--- a/src/types.rs
+++ b/src/types.rs
@@ -179,19 +179,17 @@ pub(crate) mod governance {
 		Passed,
 		Invalid,
 	}
+}
 
-	/// Storing weights of extrinsics, required in parachain registration
-	#[derive(
-		Clone, Encode, Decode, Default, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen,
-	)]
-	pub struct Weights {
-		pub report_stake_deposited: u64,
-		pub report_staking_withdraw_request: u64,
-		pub report_stake_withdrawn: u64,
-		pub report_vote_tallied: u64,
-		pub report_vote_executed: u64,
-		pub report_slash: u64,
-	}
+/// Storing weights of extrinsics, required in parachain registration
+#[derive(Clone, Encode, Decode, Default, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct Weights {
+	pub report_stake_deposited: u64,
+	pub report_staking_withdraw_request: u64,
+	pub report_stake_withdrawn: u64,
+	pub report_vote_tallied: u64,
+	pub report_vote_executed: u64,
+	pub report_slash: u64,
 }
 
 pub(super) struct U256ToBalance<T>(PhantomData<T>);

--- a/src/types.rs
+++ b/src/types.rs
@@ -179,6 +179,19 @@ pub(crate) mod governance {
 		Passed,
 		Invalid,
 	}
+
+	/// Storing weights of extrinsics, required in parachain registration
+	#[derive(
+		Clone, Encode, Decode, Default, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen,
+	)]
+	pub struct Weights {
+		pub report_stake_deposited: u64,
+		pub report_staking_withdraw_request: u64,
+		pub report_stake_withdrawn: u64,
+		pub report_vote_tallied: u64,
+		pub report_vote_executed: u64,
+		pub report_slash: u64,
+	}
 }
 
 pub(super) struct U256ToBalance<T>(PhantomData<T>);


### PR DESCRIPTION
This PR pertains to send extrinsics weights to parachain contract as each parachain will have different weights based on their pallet configuration.

Resolves: https://github.com/tellor-io/tellor-pallet/issues/90

Depends on https://github.com/tellor-io/tellor-pallet/pull/94.

This is the fresh PR for sending extrinsic weights in registration flow in order to avoid any commit confusions. For context here is the previous [PR](https://github.com/tellor-io/tellor-pallet/pull/96).