### PR TITLE
refactor: optimise storage

### DIFF
--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -78,13 +78,13 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Identifier of reported data.
 		/// # Returns
 		/// The number of past tips.
-		fn get_past_tip_count(query_id: QueryId) -> u32;
+		fn get_past_tip_count(query_id: QueryId) -> u128;
 
 		/// Read the past tips for a query identifier.
 		/// # Arguments
 		/// * `query_id` - Identifier of reported data.
 		/// # Returns
-		/// All past tips.
+		/// All past tips, in no particular order.
 		fn get_past_tips(query_id: QueryId) -> Vec<Tip<Balance>>;
 
 		/// Read a past tip for a query identifier and index.
@@ -93,7 +93,7 @@ sp_api::decl_runtime_apis! {
 		/// * `index` - The index of the tip.
 		/// # Returns
 		/// The past tip, if found.
-		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Balance>>;
+		fn get_past_tip_by_index(query_id: QueryId, index: u128) -> Option<Tip<Balance>>;
 
 		/// Look up a query identifier from a data feed identifier.
 		/// # Arguments

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -78,7 +78,7 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Identifier of reported data.
 		/// # Returns
 		/// The number of past tips.
-		fn get_past_tip_count(query_id: QueryId) -> u128;
+		fn get_past_tip_count(query_id: QueryId) -> u32;
 
 		/// Read the past tips for a query identifier.
 		/// # Arguments
@@ -93,7 +93,7 @@ sp_api::decl_runtime_apis! {
 		/// * `index` - The index of the tip.
 		/// # Returns
 		/// The past tip, if found.
-		fn get_past_tip_by_index(query_id: QueryId, index: u128) -> Option<Tip<Balance>>;
+		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Balance>>;
 
 		/// Look up a query identifier from a data feed identifier.
 		/// # Arguments
@@ -202,7 +202,7 @@ sp_api::decl_runtime_apis! {
 		/// * `reporter` - The identifier of the reporter.
 		/// # Returns
 		/// The number of values submitted by the given reporter.
-		fn get_reports_submitted_by_address(reporter: AccountId) -> u128;
+		fn get_reports_submitted_by_address(reporter: AccountId) -> u32;
 
 		/// Returns the number of values submitted to a specific query identifier by a specific reporter.
 		/// # Arguments
@@ -210,7 +210,7 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Identifier of the specific data feed.
 		/// # Returns
 		/// The number of values submitted by the given reporter to the given query identifier.
-		fn get_reports_submitted_by_address_and_query_id(reporter: AccountId, query_id: QueryId) -> u128;
+		fn get_reports_submitted_by_address_and_query_id(reporter: AccountId, query_id: QueryId) -> u32;
 
 		/// Returns the amount required to report oracle values.
 		/// # Returns
@@ -261,7 +261,7 @@ sp_api::decl_runtime_apis! {
 		/// Returns the total number of current stakers.
 		/// # Returns
 		/// The total number of current stakers.
-		fn get_total_stakers() -> u128;
+		fn get_total_stakers() -> u64;
 
 		/// Returns whether a given value is disputed.
 		/// # Arguments
@@ -317,12 +317,12 @@ sp_api::decl_runtime_apis! {
 		/// * `query_id` - Identifier of a specific data feed.
 		/// # Returns
 		/// The number of open disputes for the query identifier.
-		fn get_open_disputes_on_id(query_id: QueryId) -> u128;
+		fn get_open_disputes_on_id(query_id: QueryId) -> u32;
 
 		/// Returns the total number of votes
 		/// # Returns
 		/// The total number of votes.
-		fn get_vote_count() -> u128;
+		fn get_vote_count() -> u64;
 
 		/// Returns info on a vote for a given dispute identifier.
 		/// # Arguments
@@ -345,6 +345,6 @@ sp_api::decl_runtime_apis! {
 		/// * `voter` - The account of the voter to check for.
 		/// # Returns
 		/// The total number of votes cast by the voter.
-		fn get_vote_tally_by_address(voter: AccountId) -> u128;
+		fn get_vote_tally_by_address(voter: AccountId) -> u32;
 	}
 }

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -60,7 +60,7 @@ sp_api::decl_runtime_apis! {
 
 		/// Read currently funded feeds.
 		/// # Returns
-		/// The currently funded feeds
+		/// The currently funded feeds, in no particular order.
 		fn get_funded_feeds() -> Vec<FeedId>;
 
 		/// Read query identifiers with current one-time tips.

--- a/runtime-api/src/lib.rs
+++ b/runtime-api/src/lib.rs
@@ -65,7 +65,7 @@ sp_api::decl_runtime_apis! {
 
 		/// Read query identifiers with current one-time tips.
 		/// # Returns
-		/// Query identifiers with current one-time tips.
+		/// Query identifiers with current one-time tips, in no particular order.
 		fn get_funded_query_ids() -> Vec<QueryId>;
 
 		/// Read currently funded single tips with query data.

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -121,7 +121,6 @@ impl tellor::Config for Test {
 	type GovernanceOrigin = EnsureGovernance;
 	type InitialDisputeFee = ();
 	type MaxClaimTimestamps = ();
-	type MaxFundedFeeds = ();
 	type MaxQueryDataLength = ();
 	type MaxTipsPerQuery = ();
 	type MaxValueLength = MaxValueLength;

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -122,7 +122,6 @@ impl tellor::Config for Test {
 	type InitialDisputeFee = ();
 	type MaxClaimTimestamps = ();
 	type MaxQueryDataLength = ();
-	type MaxTipsPerQuery = ();
 	type MaxValueLength = MaxValueLength;
 	type MaxVotes = ();
 	type MinimumStakeAmount = ();

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -196,7 +196,7 @@ mock_impl_runtime_apis! {
 			.collect()
 		}
 
-		fn get_past_tip_count(query_id: QueryId) -> u128 {
+		fn get_past_tip_count(query_id: QueryId) -> u32 {
 			tellor::Pallet::<Test>::get_past_tip_count(query_id)
 		}
 
@@ -204,7 +204,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_past_tips(query_id)
 		}
 
-		fn get_past_tip_by_index(query_id: QueryId, index: u128) -> Option<Tip<Balance>>{
+		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Balance>>{
 			tellor::Pallet::<Test>::get_past_tip_by_index(query_id, index)
 		}
 
@@ -262,11 +262,11 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_reporting_lock()
 		}
 
-		fn get_reports_submitted_by_address(reporter: AccountId) -> u128 {
+		fn get_reports_submitted_by_address(reporter: AccountId) -> u32 {
 			tellor::Pallet::<Test>::get_reports_submitted_by_address(&reporter)
 		}
 
-		fn get_reports_submitted_by_address_and_query_id(reporter: AccountId, query_id: QueryId) -> u128 {
+		fn get_reports_submitted_by_address_and_query_id(reporter: AccountId, query_id: QueryId) -> u32 {
 			tellor::Pallet::<Test>::get_reports_submitted_by_address_and_query_id(reporter, query_id)
 		}
 
@@ -298,7 +298,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_total_stake_amount()
 		}
 
-		fn get_total_stakers() -> u128 {
+		fn get_total_stakers() -> u64 {
 			tellor::Pallet::<Test>::get_total_stakers()
 		}
 
@@ -328,11 +328,11 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_dispute_info(dispute_id)
 		}
 
-		fn get_open_disputes_on_id(query_id: QueryId) -> u128 {
+		fn get_open_disputes_on_id(query_id: QueryId) -> u32 {
 			tellor::Pallet::<Test>::get_open_disputes_on_id(query_id)
 		}
 
-		fn get_vote_count() -> u128 {
+		fn get_vote_count() -> u64 {
 			tellor::Pallet::<Test>::get_vote_count()
 		}
 
@@ -360,7 +360,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_vote_rounds(dispute_id)
 		}
 
-		fn get_vote_tally_by_address(voter: AccountId) -> u128 {
+		fn get_vote_tally_by_address(voter: AccountId) -> u32 {
 			tellor::Pallet::<Test>::get_vote_tally_by_address(&voter)
 		}
 	}

--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -197,7 +197,7 @@ mock_impl_runtime_apis! {
 			.collect()
 		}
 
-		fn get_past_tip_count(query_id: QueryId) -> u32 {
+		fn get_past_tip_count(query_id: QueryId) -> u128 {
 			tellor::Pallet::<Test>::get_past_tip_count(query_id)
 		}
 
@@ -205,7 +205,7 @@ mock_impl_runtime_apis! {
 			tellor::Pallet::<Test>::get_past_tips(query_id)
 		}
 
-		fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<Balance>>{
+		fn get_past_tip_by_index(query_id: QueryId, index: u128) -> Option<Tip<Balance>>{
 			tellor::Pallet::<Test>::get_past_tip_by_index(query_id, index)
 		}
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -640,9 +640,9 @@ impl<T: Config> Pallet<T> {
 
 	/// Read query identifiers with current one-time tips.
 	/// # Returns
-	/// Query identifiers with current one-time tips.
+	/// Query identifiers with current one-time tips, in no particular order.
 	pub fn get_funded_query_ids() -> Vec<QueryId> {
-		<QueryIdsWithFunding<T>>::get().to_vec()
+		<QueryIdsWithFunding<T>>::iter_keys().collect()
 	}
 
 	/// Read currently funded single tips with query data.

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -373,15 +373,15 @@ impl<T: Config> Pallet<T> {
 					match supports {
 						// Invalid
 						None => {
-							vote.reporters.invalid_query.saturating_accrue(reports);
+							vote.reporters.invalid_query.saturating_accrue(reports.into());
 							vote.users.invalid_query.saturating_accrue(user_tips);
 						},
 						Some(supports) =>
 							if supports {
-								vote.reporters.does_support.saturating_accrue(reports);
+								vote.reporters.does_support.saturating_accrue(reports.into());
 								vote.users.does_support.saturating_accrue(user_tips);
 							} else {
-								vote.reporters.against.saturating_accrue(reports);
+								vote.reporters.against.saturating_accrue(reports.into());
 								vote.users.against.saturating_accrue(user_tips);
 							},
 					};
@@ -865,7 +865,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of a specific data feed.
 	/// # Returns
 	/// The number of open disputes for the query identifier.
-	pub fn get_open_disputes_on_id(query_id: QueryId) -> u128 {
+	pub fn get_open_disputes_on_id(query_id: QueryId) -> u32 {
 		<OpenDisputesOnId<T>>::get(query_id).unwrap_or_default()
 	}
 
@@ -874,7 +874,7 @@ impl<T: Config> Pallet<T> {
 	/// * `query_id` - Identifier of reported data.
 	/// # Returns
 	/// The number of past tips.
-	pub fn get_past_tip_count(query_id: QueryId) -> u128 {
+	pub fn get_past_tip_count(query_id: QueryId) -> u32 {
 		<TipCount<T>>::get(query_id)
 	}
 
@@ -893,7 +893,7 @@ impl<T: Config> Pallet<T> {
 	/// * `index` - The index of the tip.
 	/// # Returns
 	/// The past tip, if found.
-	pub fn get_past_tip_by_index(query_id: QueryId, index: u128) -> Option<Tip<BalanceOf<T>>> {
+	pub fn get_past_tip_by_index(query_id: QueryId, index: u32) -> Option<Tip<BalanceOf<T>>> {
 		<Tips<T>>::get(query_id, index)
 	}
 
@@ -958,7 +958,7 @@ impl<T: Config> Pallet<T> {
 	/// * `reporter` - The identifier of the reporter.
 	/// # Returns
 	/// The number of values submitted by the given reporter.
-	pub fn get_reports_submitted_by_address(reporter: &AccountIdOf<T>) -> u128 {
+	pub fn get_reports_submitted_by_address(reporter: &AccountIdOf<T>) -> u32 {
 		<StakerDetails<T>>::get(reporter)
 			.map(|stake_info| stake_info.reports_submitted)
 			.unwrap_or_default()
@@ -973,7 +973,7 @@ impl<T: Config> Pallet<T> {
 	pub fn get_reports_submitted_by_address_and_query_id(
 		reporter: AccountIdOf<T>,
 		query_id: QueryId,
-	) -> u128 {
+	) -> u32 {
 		<StakerReportsSubmittedByQueryId<T>>::get(reporter, query_id)
 	}
 
@@ -1104,7 +1104,7 @@ impl<T: Config> Pallet<T> {
 	/// Returns the total number of current stakers.
 	/// # Returns
 	/// The total number of current stakers.
-	pub fn get_total_stakers() -> u128 {
+	pub fn get_total_stakers() -> u64 {
 		<TotalStakers<T>>::get()
 	}
 
@@ -1120,7 +1120,7 @@ impl<T: Config> Pallet<T> {
 	/// Returns the total number of votes
 	/// # Returns
 	/// The total number of votes.
-	pub fn get_vote_count() -> u128 {
+	pub fn get_vote_count() -> u64 {
 		<VoteCount<T>>::get()
 	}
 
@@ -1149,7 +1149,7 @@ impl<T: Config> Pallet<T> {
 	/// * `voter` - The account of the voter to check for.
 	/// # Returns
 	/// The total number of votes cast by the voter.
-	pub fn get_vote_tally_by_address(voter: &AccountIdOf<T>) -> u128 {
+	pub fn get_vote_tally_by_address(voter: &AccountIdOf<T>) -> u32 {
 		<VoteTallyByAddress<T>>::get(voter)
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,10 +142,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxQueryDataLength: Get<u32>;
 
-		/// The maximum number of tips per query.
-		#[pallet::constant]
-		type MaxTipsPerQuery: Get<u32>;
-
 		/// The maximum length of an individual value submitted to the oracle.
 		#[pallet::constant]
 		type MaxValueLength: Get<u32>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,7 @@ pub mod pallet {
 	}
 
 	// AutoPay
+	/// Mapping query identifier and feed identifier to feed details
 	#[pallet::storage]
 	pub(super) type DataFeeds<T> =
 		StorageDoubleMap<_, Identity, QueryId, Identity, FeedId, FeedOf<T>>;
@@ -234,17 +235,23 @@ pub mod pallet {
 		bool,
 		ValueQuery,
 	>;
+	/// Feed identifiers that have funding
 	#[pallet::storage]
 	pub(super) type FeedsWithFunding<T> = StorageMap<_, Identity, FeedId, ()>;
+	/// Mapping feed identifier to query identifier
 	#[pallet::storage]
 	pub(super) type QueryIdFromDataFeedId<T> = StorageMap<_, Identity, FeedId, QueryId>;
+	// Query identifiers that have funding
 	#[pallet::storage]
 	pub(super) type QueryIdsWithFunding<T> = StorageMap<_, Identity, QueryId, ()>;
+	/// Mapping query identifier (and index) to tips
 	#[pallet::storage]
 	pub(super) type Tips<T> =
 		StorageDoubleMap<_, Identity, QueryId, Blake2_128Concat, u128, TipOf<T>>;
+	/// Total tip count per query identifier
 	#[pallet::storage]
 	pub(super) type TipCount<T> = StorageMap<_, Identity, QueryId, u128, ValueQuery>;
+	/// Tracks user tip total per user
 	#[pallet::storage]
 	pub(super) type UserTipsTotal<T> =
 		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, BalanceOf<T>, ValueQuery>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,8 +509,6 @@ pub mod pallet {
 		InvalidTimestamp,
 		/// Window must be less than interval length.
 		InvalidWindow,
-		/// The maximum number of tips has been reached,
-		MaxTipsReached,
 		/// No tips submitted for this query identifier.
 		NoTipsSubmitted,
 		/// Price threshold not met.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,10 +138,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxClaimTimestamps: Get<u32>;
 
-		/// The maximum number of funded feeds.
-		#[pallet::constant]
-		type MaxFundedFeeds: Get<u32>;
-
 		/// The maximum length of query data.
 		#[pallet::constant]
 		type MaxQueryDataLength: Get<u32>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,8 +511,6 @@ pub mod pallet {
 		InvalidTimestamp,
 		/// Window must be less than interval length.
 		InvalidWindow,
-		/// The maximum number of feeds have been funded.
-		MaxFeedsFunded,
 		/// The maximum number of tips has been reached,
 		MaxTipsReached,
 		/// No tips submitted for this query identifier.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,10 +247,10 @@ pub mod pallet {
 	/// Mapping query identifier (and index) to tips
 	#[pallet::storage]
 	pub(super) type Tips<T> =
-		StorageDoubleMap<_, Identity, QueryId, Blake2_128Concat, u128, TipOf<T>>;
+		StorageDoubleMap<_, Identity, QueryId, Blake2_128Concat, u32, TipOf<T>>;
 	/// Total tip count per query identifier
 	#[pallet::storage]
-	pub(super) type TipCount<T> = StorageMap<_, Identity, QueryId, u128, ValueQuery>;
+	pub(super) type TipCount<T> = StorageMap<_, Identity, QueryId, u32, ValueQuery>;
 	/// Tracks user tip total per user
 	#[pallet::storage]
 	pub(super) type UserTipsTotal<T> =
@@ -305,7 +305,7 @@ pub mod pallet {
 	/// Mapping of reporter and query identifier to number of reports submitted.
 	#[pallet::storage]
 	pub(super) type StakerReportsSubmittedByQueryId<T> =
-		StorageDoubleMap<_, Blake2_128Concat, AccountIdOf<T>, Identity, QueryId, u128, ValueQuery>;
+		StorageDoubleMap<_, Blake2_128Concat, AccountIdOf<T>, Identity, QueryId, u32, ValueQuery>;
 	/// The time of last update to AccumulatedRewardPerShare.
 	#[pallet::storage]
 	#[pallet::getter(fn time_of_last_allocation)]
@@ -323,7 +323,7 @@ pub mod pallet {
 	pub(super) type TotalStakeAmount<T> = StorageValue<_, Tributes, ValueQuery>;
 	/// Total number of stakers with at least StakeAmount staked, not exact.
 	#[pallet::storage]
-	pub(super) type TotalStakers<T> = StorageValue<_, u128, ValueQuery>;
+	pub(super) type TotalStakers<T> = StorageValue<_, u64, ValueQuery>;
 	/// Amount locked for withdrawal.
 	#[pallet::storage]
 	pub(super) type ToWithdraw<T> = StorageValue<_, Tributes, ValueQuery>;
@@ -340,13 +340,13 @@ pub mod pallet {
 	pub(super) type DisputeInfo<T> = StorageMap<_, Identity, DisputeId, DisputeOf<T>>;
 	/// Mapping of a query identifier to the number of corresponding open disputes.
 	#[pallet::storage]
-	pub(super) type OpenDisputesOnId<T> = StorageMap<_, Identity, QueryId, u128>;
+	pub(super) type OpenDisputesOnId<T> = StorageMap<_, Identity, QueryId, u32>;
 	/// Any pending votes which are queued to be sent to the governance controller contract for tallying.
 	#[pallet::storage]
 	pub(super) type PendingVotes<T> = StorageMap<_, Identity, DisputeId, (u8, Timestamp)>;
 	/// Total number of votes initiated.
 	#[pallet::storage]
-	pub(super) type VoteCount<T> = StorageValue<_, u128, ValueQuery>;
+	pub(super) type VoteCount<T> = StorageValue<_, u64, ValueQuery>;
 	/// Mapping of dispute identifiers to the details of the vote round.
 	#[pallet::storage]
 	pub(super) type VoteInfo<T> =
@@ -369,7 +369,7 @@ pub mod pallet {
 	/// Mapping of addresses to the number of votes they have cast.
 	#[pallet::storage]
 	pub(super) type VoteTallyByAddress<T> =
-		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, u128, ValueQuery>;
+		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, u32, ValueQuery>;
 	// Query Data
 	#[pallet::storage]
 	pub(super) type QueryData<T> = StorageMap<_, Identity, QueryId, QueryDataOf<T>>;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -137,7 +137,6 @@ impl tellor::Config for Test {
 	type GovernanceOrigin = EnsureGovernance;
 	type InitialDisputeFee = ConstU128<{ 50 * 10u128.pow(12) }>; // (100 TRB / 10) * 5, where TRB 1:5 OCP
 	type MaxClaimTimestamps = ConstU32<100>; // 100 timestamps per claim
-	type MaxFundedFeeds = ConstU32<1024>; // 1024 feeds
 	type MaxQueryDataLength = ConstU32<1024>;
 	type MaxTipsPerQuery = ConstU32<100>; // 100 tips per query id
 	type MaxValueLength = ConstU32<256>;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -138,7 +138,6 @@ impl tellor::Config for Test {
 	type InitialDisputeFee = ConstU128<{ 50 * 10u128.pow(12) }>; // (100 TRB / 10) * 5, where TRB 1:5 OCP
 	type MaxClaimTimestamps = ConstU32<100>; // 100 timestamps per claim
 	type MaxQueryDataLength = ConstU32<1024>;
-	type MaxTipsPerQuery = ConstU32<100>; // 100 tips per query id
 	type MaxValueLength = ConstU32<256>;
 	type MaxVotes = ConstU32<10>; // 10 votes max when voting on multiple disputes
 	type MinimumStakeAmount = MinimumStakeAmount;

--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -1735,7 +1735,6 @@ fn get_funded_query_ids() {
 				query_data_1.clone()
 			));
 			assert_eq!(Tellor::get_funded_query_ids(), vec![query_id_1]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1).unwrap(), 1);
 			// Tip queryId 1 again
 			assert_ok!(Tellor::tip(
 				RuntimeOrigin::signed(tipper),
@@ -1744,7 +1743,6 @@ fn get_funded_query_ids() {
 				query_data_1.clone()
 			));
 			assert_eq!(Tellor::get_funded_query_ids(), vec![query_id_1]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1).unwrap(), 1);
 			// Tip queryId 2
 			assert_ok!(Tellor::tip(
 				RuntimeOrigin::signed(tipper),
@@ -1753,8 +1751,6 @@ fn get_funded_query_ids() {
 				query_data_2.clone()
 			));
 			assert_eq!(Tellor::get_funded_query_ids(), vec![query_id_1, query_id_2]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1).unwrap(), 1);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_2).unwrap(), 2);
 			// Tip queryId 2 again
 			assert_ok!(Tellor::tip(
 				RuntimeOrigin::signed(tipper),
@@ -1770,10 +1766,10 @@ fn get_funded_query_ids() {
 				token(1),
 				query_data_3.clone()
 			));
-			assert_eq!(Tellor::get_funded_query_ids(), vec![query_id_1, query_id_2, query_id_3]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1).unwrap(), 1);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_2).unwrap(), 2);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_3).unwrap(), 3);
+			assert_eq!(
+				sort(Tellor::get_funded_query_ids()),
+				sort(vec![query_id_1, query_id_2, query_id_3])
+			);
 			// Tip queryId 4
 			assert_ok!(Tellor::tip(
 				RuntimeOrigin::signed(tipper),
@@ -1782,13 +1778,9 @@ fn get_funded_query_ids() {
 				query_data_4.clone()
 			));
 			assert_eq!(
-				Tellor::get_funded_query_ids(),
-				vec![query_id_1, query_id_2, query_id_3, query_id_4]
+				sort(Tellor::get_funded_query_ids()),
+				sort(vec![query_id_1, query_id_2, query_id_3, query_id_4])
 			);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1).unwrap(), 1);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_2).unwrap(), 2);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_3).unwrap(), 3);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_4).unwrap(), 4);
 		});
 
 		let timestamp_1 = with_block_after(REPORTING_LOCK, || {
@@ -1841,11 +1833,10 @@ fn get_funded_query_ids() {
 				query_id_1,
 				bounded_vec![timestamp_1.into()]
 			));
-			assert_eq!(Tellor::get_funded_query_ids(), vec![query_id_4, query_id_2, query_id_3]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_2).unwrap(), 2);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_3).unwrap(), 3);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_4).unwrap(), 1);
+			assert_eq!(
+				sort(Tellor::get_funded_query_ids()),
+				sort(vec![query_id_4, query_id_2, query_id_3])
+			);
 
 			// Tip queryId 2
 			assert_ok!(Tellor::tip(
@@ -1860,22 +1851,17 @@ fn get_funded_query_ids() {
 				query_id_2,
 				bounded_vec![timestamp_2.into()]
 			));
-			assert_eq!(Tellor::get_funded_query_ids(), vec![query_id_4, query_id_2, query_id_3]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_2).unwrap(), 2);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_3).unwrap(), 3);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_4).unwrap(), 1);
+			assert_eq!(
+				sort(Tellor::get_funded_query_ids()),
+				sort(vec![query_id_4, query_id_2, query_id_3])
+			);
 
 			assert_ok!(Tellor::claim_onetime_tip(
 				RuntimeOrigin::signed(reporter),
 				query_id_3,
 				bounded_vec![timestamp_3.into()]
 			));
-			assert_eq!(Tellor::get_funded_query_ids(), vec![query_id_4, query_id_2]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_2).unwrap(), 2);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_3), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_4).unwrap(), 1);
+			assert_eq!(sort(Tellor::get_funded_query_ids()), sort(vec![query_id_4, query_id_2]));
 
 			assert_ok!(Tellor::claim_onetime_tip(
 				RuntimeOrigin::signed(reporter),
@@ -1883,10 +1869,6 @@ fn get_funded_query_ids() {
 				bounded_vec![timestamp_4.into()]
 			));
 			assert_eq!(Tellor::get_funded_query_ids(), vec![query_id_2]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_2).unwrap(), 1);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_3), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_4), None);
 		});
 
 		let timestamp_2 = with_block(|| {
@@ -1907,10 +1889,6 @@ fn get_funded_query_ids() {
 				bounded_vec![timestamp_2.into()]
 			));
 			assert_eq!(Tellor::get_funded_query_ids(), vec![]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_2), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_3), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_4), None);
 
 			// Tip queryId 4
 			assert_ok!(Tellor::tip(
@@ -1920,10 +1898,6 @@ fn get_funded_query_ids() {
 				query_data_4.clone()
 			));
 			assert_eq!(Tellor::get_funded_query_ids(), vec![query_id_4]);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_1), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_2), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_3), None);
-			assert_eq!(Tellor::query_ids_with_funding_index(query_id_4).unwrap(), 1);
 		});
 	});
 }
@@ -2370,7 +2344,7 @@ fn get_current_feeds() {
 	});
 }
 
-fn sort(mut feeds: Vec<FeedId>) -> Vec<FeedId> {
+fn sort(mut feeds: Vec<H256>) -> Vec<H256> {
 	feeds.sort();
 	feeds
 }

--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -1225,7 +1225,7 @@ fn claim_onetime_tip() {
 				bounded_vec![timestamp.into()]
 			));
 			assert_eq!(Tellor::get_current_tip(query_id), 0, "tip should be correct");
-			for tip in Tips::get(query_id).unwrap() {
+			for tip in Tips::iter_prefix_values(query_id) {
 				assert_eq!(tip.amount, 0);
 			}
 			let final_balance = Balances::balance(&reporter);
@@ -1362,8 +1362,8 @@ fn get_past_tips() {
 		});
 
 		assert_eq!(
-			Tellor::get_past_tips(query_id),
-			vec![
+			sort_tips(Tellor::get_past_tips(query_id)),
+			sort_tips(vec![
 				TipOf::<Test> {
 					amount: token(100),
 					timestamp: timestamp_1 + 1,
@@ -1374,7 +1374,7 @@ fn get_past_tips() {
 					timestamp: timestamp_2 + 1,
 					cumulative_tips: token(300)
 				}
-			],
+			]),
 			"past tips should be correct"
 		);
 
@@ -1389,8 +1389,8 @@ fn get_past_tips() {
 		});
 
 		assert_eq!(
-			Tellor::get_past_tips(query_id),
-			vec![
+			sort_tips(Tellor::get_past_tips(query_id)),
+			sort_tips(vec![
 				TipOf::<Test> {
 					amount: token(100),
 					timestamp: timestamp_1 + 1,
@@ -1401,7 +1401,7 @@ fn get_past_tips() {
 					timestamp: timestamp_3 + 1,
 					cumulative_tips: token(600)
 				}
-			],
+			]),
 			"past tips should be correct"
 		);
 	});
@@ -2344,9 +2344,14 @@ fn get_current_feeds() {
 	});
 }
 
-fn sort(mut feeds: Vec<H256>) -> Vec<H256> {
-	feeds.sort();
-	feeds
+fn sort(mut items: Vec<H256>) -> Vec<H256> {
+	items.sort();
+	items
+}
+
+fn sort_tips(mut items: Vec<TipOf<Test>>) -> Vec<TipOf<Test>> {
+	items.sort_by_key(|t| t.timestamp);
+	items
 }
 
 // Helper function for creating feeds

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,11 +97,11 @@ pub(crate) mod oracle {
 		/// Timestamp of reporter's last reported value.
 		pub(crate) reporter_last_timestamp: Timestamp,
 		/// Total number of reports submitted by reporter.
-		pub(crate) reports_submitted: u128,
+		pub(crate) reports_submitted: u32,
 		/// Total number of governance votes when stake deposited.
-		pub(crate) start_vote_count: u128,
+		pub(crate) start_vote_count: u64,
 		/// Staker vote tally when stake deposited.
-		pub(crate) start_vote_tally: u128,
+		pub(crate) start_vote_tally: u32,
 		/// Used to keep track of total stakers.
 		pub(crate) staked: bool,
 	}

--- a/src/types.rs
+++ b/src/types.rs
@@ -64,8 +64,6 @@ pub(crate) mod autopay {
 		pub(crate) price_threshold: u16,
 		/// Amount reward increases per second within the window (0 for flat rewards).
 		pub(crate) reward_increase_per_second: Balance,
-		/// Index plus one of data feed identifier in FeedsWithFunding storage (0 if not included).
-		pub(crate) feeds_with_funding_index: u32,
 	}
 
 	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]


### PR DESCRIPTION
- refactors `FeedsWithFunding`, `QueryIdsWithFunding` and `Tips` storage items to use maps, eliminating the need to track array indices
- adds `TipCount` storage item
- removes `QueryIdsWithFundingIndex` storage item as no longer required
- removes `Feed.feeds_with_funding_index` as no longer required
- removes `MaxFundedFeeds` and `MaxTipsPerQuery` config items as no longer necessary
- removes `MaxFeedsFunded` and `MaxTipsReached` error variants no longer used