### PR TITLE
Update decimals to 18 

### DIFF
--- a/src/benchmarking.rs
+++ b/src/benchmarking.rs
@@ -45,9 +45,9 @@ fn trb(amount: impl Into<f64>) -> Tributes {
 	Tributes::from((amount.into() * TRB as f64) as u128)
 }
 
-fn token<T: Config>(amount: impl Into<u64>) -> BalanceOf<T> {
+fn token<T: Config>(amount: impl Into<u128>) -> BalanceOf<T> {
 	// consumer parachain token
-	(amount.into() * unit::<T>() as u64).into()
+	(amount.into() * unit::<T>() as u128).into()
 }
 
 fn unit<T: Config>() -> u128 {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -777,7 +777,7 @@ impl<T: Config> Pallet<T> {
 		);
 		let tip_count = <TipCount<T>>::get(query_id);
 		if tip_count == 0 {
-			return Err(Error::<T>::NoTipsSubmitted.into())
+			Err(Error::<T>::NoTipsSubmitted.into())
 		} else {
 			let mut min = 0;
 			let mut max = tip_count;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -130,12 +130,12 @@ impl tellor::Config for Test {
 	type RuntimeOrigin = RuntimeOrigin;
 	type Asset = Balances;
 	type Balance = Balance;
-	type Decimals = ConstU8<12>;
+	type Decimals = ConstU8<18>;
 	type Fee = ConstU16<10>; // 1%
 	type FeeLocation = FeeLocation;
 	type Governance = TellorGovernance;
 	type GovernanceOrigin = EnsureGovernance;
-	type InitialDisputeFee = ConstU128<{ 50 * 10u128.pow(12) }>; // (100 TRB / 10) * 5, where TRB 1:5 OCP
+	type InitialDisputeFee = ConstU128<{ 50 * 10u128.pow(18) }>; // (100 TRB / 10) * 5, where TRB 1:5 OCP
 	type MaxClaimTimestamps = ConstU32<100>; // 100 timestamps per claim
 	type MaxQueryDataLength = ConstU32<1024>;
 	type MaxValueLength = ConstU32<256>;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -154,7 +154,7 @@ fn xcm_transact(call: DoubleEncoded<RuntimeCall>, gas_limit: u64) -> (MultiLocat
 
 #[test]
 fn converts_token() {
-	assert_eq!(token(2.97), 2_970_000_000_000)
+	assert_eq!(token(2.97), 2_970_000_000_000_000_000)
 }
 
 #[test]


### PR DESCRIPTION
This PR pertains to fixing decimals from 12 to 18.

Reason for this change: In the business logic, we are dealing with stake_amount which has 18 decimals and rest is dealing with 12 decimals which is conflicting while calculating rewards.