### PR TITLE
fix: use staking origin for report_slash

### DIFF
--- a/src/benchmarking.rs
+++ b/src/benchmarking.rs
@@ -530,6 +530,7 @@ benchmarks! {
 		// tally vote
 		Tellor::<T>::report_vote_tallied(caller.clone(), dispute_id, VoteResult::Passed)?;
 
+		let caller = T::StakingOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 	}: _<RuntimeOrigin<T>>(caller, reporter.clone(), trb(100))
 	verify {
 		assert_last_event::<T>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1487,8 +1487,8 @@ pub mod pallet {
 			reporter: AccountIdOf<T>,
 			amount: Tributes,
 		) -> DispatchResult {
-			// ensure origin is governance controller contract
-			T::GovernanceOrigin::ensure_origin(origin)?;
+			// ensure origin is staking controller contract
+			T::StakingOrigin::ensure_origin(origin)?;
 
 			<StakerDetails<T>>::try_mutate(&reporter, |maybe| -> DispatchResult {
 				match maybe {

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -141,7 +141,7 @@ fn begin_dispute() {
 		// Report slash after tally dispute period
 		with_block_after(86_400 * 2, || {
 			assert_ok!(Tellor::report_slash(
-				Origin::Governance.into(),
+				Origin::Staking.into(), // Call originates from staking contract, via governance contract call
 				reporter,
 				MINIMUM_STAKE_AMOUNT.into()
 			));
@@ -296,7 +296,7 @@ fn begin_dispute_by_non_reporter() {
 		// Report slash after tally dispute period
 		with_block_after(86_400 * 2, || {
 			assert_ok!(Tellor::report_slash(
-				Origin::Governance.into(),
+				Origin::Staking.into(), // Call originates from staking contract, via governance contract call
 				reporter,
 				MINIMUM_STAKE_AMOUNT.into()
 			));

--- a/src/tests/oracle.rs
+++ b/src/tests/oracle.rs
@@ -496,14 +496,14 @@ fn slash_reporter() {
 			assert_eq!(Tellor::get_total_stake_amount(), amount);
 			assert_noop!(
 				Tellor::report_slash(
-					Origin::Governance.into(),
+					Origin::Staking.into(), // Call originates from staking contract, via governance contract call
 					0,
 					(MINIMUM_STAKE_AMOUNT + 1).into()
 				),
 				Error::InsufficientStake
 			);
 			assert_ok!(Tellor::report_slash(
-				Origin::Governance.into(),
+				Origin::Staking.into(), // Call originates from staking contract, via governance contract call
 				reporter,
 				MINIMUM_STAKE_AMOUNT.into()
 			));
@@ -543,7 +543,7 @@ fn slash_reporter() {
 			assert_eq!(staker_details.locked_balance, trb(100));
 			assert!(staker_details.staked);
 			assert_ok!(Tellor::report_slash(
-				Origin::Governance.into(),
+				Origin::Staking.into(), // Call originates from staking contract, via governance contract call
 				reporter,
 				MINIMUM_STAKE_AMOUNT.into()
 			));
@@ -581,7 +581,7 @@ fn slash_reporter() {
 			assert_eq!(staker_details.locked_balance, trb(5));
 			assert_eq!(Tellor::get_total_stake_amount(), trb(795));
 			assert_ok!(Tellor::report_slash(
-				Origin::Governance.into(),
+				Origin::Staking.into(), // Call originates from staking contract, via governance contract call
 				reporter,
 				MINIMUM_STAKE_AMOUNT.into()
 			));
@@ -628,7 +628,7 @@ fn slash_reporter() {
 		// Report slash after tally dispute period
 		with_block_after(86_400, || {
 			assert_ok!(Tellor::report_slash(
-				Origin::Governance.into(),
+				Origin::Staking.into(), // Call originates from staking contract, via governance contract call
 				reporter,
 				MINIMUM_STAKE_AMOUNT.into()
 			));


### PR DESCRIPTION
Parachain governance contract calls staking contract ([ref](https://github.com/tellor-io/tellor-parachain-contracts/blob/f693960b6709a84a372b8bb34abf3afbe1a03404/src/ParachainGovernance.sol#L168)) to slash reporter on dispute , resulting in the originating address of the `report_slash` call ([ref](https://github.com/tellor-io/tellor-parachain-contracts/blob/f693960b6709a84a372b8bb34abf3afbe1a03404/src/ParachainStaking.sol#L264)) being the staking contract rather than governance.