### PR TITLE
fix: correct reporter on newdispute event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1225,7 +1225,7 @@ pub mod pallet {
 				dispute_id,
 				query_id,
 				timestamp,
-				reporter: dispute_initiator,
+				reporter: dispute.disputed_reporter.clone(),
 			});
 
 			// Lookup corresponding address on controller chain

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -94,6 +94,9 @@ fn begin_dispute() {
 				None,
 			));
 			let dispute_id = dispute_id(PARA_ID, query_id, timestamp);
+			System::assert_has_event(
+				Event::NewDispute { dispute_id, query_id, timestamp, reporter }.into(),
+			);
 			let dispute_info = Tellor::get_dispute_info(dispute_id).unwrap();
 			let vote_info = Tellor::get_vote_info(dispute_id, 1).unwrap();
 			assert_eq!(Tellor::get_vote_count(), 1, "vote count should be correct");


### PR DESCRIPTION
`reporter` should be the disputed reporter and not the reporter of the dispute.