### PR TITLE
Externalise XCM message weighing

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -16,6 +16,7 @@
 
 use super::*;
 use crate::constants::DECIMALS;
+use ::xcm::prelude::Parachain;
 use frame_support::traits::fungible::Inspect;
 use sp_runtime::{
 	traits::{CheckedAdd, CheckedMul, CheckedSub, Hash},
@@ -285,6 +286,7 @@ impl<T: Config> Pallet<T> {
 						GAS_LIMIT,
 					),
 					GAS_LIMIT,
+					Parachain(governance_contract.para_id).into(),
 				);
 				Self::send_xcm(
 					governance_contract.para_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub mod pallet {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	use crate::traits::BenchmarkHelper;
-	use crate::types::Weights;
+	use crate::{traits::Weigher, types::Weights};
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
@@ -225,6 +225,9 @@ pub mod pallet {
 			Self::Balance,
 			Self::MaxQueryDataLength,
 		>;
+
+		/// Means of measuring the weight consumed by an XCM message.
+		type Weigher: Weigher;
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
@@ -668,6 +671,7 @@ pub mod pallet {
 					GAS_LIMIT,
 				),
 				GAS_LIMIT,
+				Parachain(T::Registry::get().para_id).into(),
 			);
 			Self::send_xcm(
 				registry_contract.para_id,
@@ -1252,6 +1256,7 @@ pub mod pallet {
 					GAS_LIMIT,
 				),
 				GAS_LIMIT,
+				Parachain(governance_contract.para_id).into(),
 			);
 			Self::send_xcm(
 				governance_contract.para_id,
@@ -1421,6 +1426,7 @@ pub mod pallet {
 					GAS_LIMIT,
 				),
 				GAS_LIMIT,
+				Parachain(staking_contract.para_id).into(),
 			);
 			Self::send_xcm(
 				staking_contract.para_id,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -16,11 +16,19 @@
 
 use crate as tellor;
 use crate::{
-	constants::HOURS, types::Address, xcm::ContractLocation, EnsureGovernance, EnsureStaking,
+	constants::HOURS,
+	traits::{UniversalWeigher, Weigher},
+	types::Address,
+	xcm::ContractLocation,
+	EnsureGovernance, EnsureStaking,
 };
 use frame_support::{
 	assert_ok, log, parameter_types,
 	traits::{ConstU16, ConstU64, OnFinalize, UnixTime},
+	weights::{
+		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
+		Weight,
+	},
 	Hashable, PalletId,
 };
 #[cfg(feature = "runtime-benchmarks")]
@@ -159,6 +167,7 @@ impl tellor::Config for Test {
 	type XcmWeightToAsset = ConstU128<50_000>; // Moonbase Alpha: https://github.com/PureStake/moonbeam/blob/f19ba9de013a1c789425d3b71e8a92d54f2191af/runtime/moonbase/src/lib.rs#L135
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = TestBenchmarkHelper;
+	type Weigher = MoonbeamWeights;
 	type WeightInfo = ();
 }
 
@@ -287,4 +296,69 @@ pub(crate) fn with_block_after<R>(time_in_secs: u64, execute: impl FnOnce() -> R
 	System::reset_events();
 	SENT_XCM.with(|q| q.borrow_mut().clear());
 	result
+}
+
+impl UniversalWeigher for MoonbeamWeights {
+	fn weigh(dest: impl Into<MultiLocation>, message: Xcm<()>) -> Result<Weight, ()> {
+		let mut weight: Weight = Weight::zero();
+		return match dest.into() {
+			MultiLocation { parents: _, interior: X1(Parachain(EVM_PARA_ID)) } => {
+				for instruction in message.0.iter() {
+					match instruction {
+						DescendOrigin(_) =>
+							weight =
+								weight.checked_add(&MoonbeamWeights::descend_origin()).ok_or(())?,
+						WithdrawAsset(_) =>
+							weight =
+								weight.checked_add(&MoonbeamWeights::withdraw_asset()).ok_or(())?,
+						BuyExecution { .. } =>
+							weight =
+								weight.checked_add(&MoonbeamWeights::buy_execution()).ok_or(())?,
+						Transact { .. } =>
+							weight = weight.checked_add(&MoonbeamWeights::transact()).ok_or(())?,
+						_ => weight = weight.checked_add(&Weight::zero()).ok_or(())?,
+					};
+				}
+				Ok(weight)
+			},
+			_ => {
+				log::trace!(target: "xcm::UniversalWeigher", "Invalid MultiLocation");
+				Err(())
+			},
+		}
+	}
+}
+
+impl Weigher for MoonbeamWeights {
+	fn transact(dest: impl Into<MultiLocation>, gas_limit: u64) -> Weight {
+		return match dest.into() {
+			MultiLocation { parents: _, interior: X1(Parachain(EVM_PARA_ID)) } => {
+				// https://github.com/PureStake/moonbeam/blob/master/runtime/moonbase/src/lib.rs#L371-L375
+				const GAS_PER_SECOND: u64 = 40_000_000;
+				const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND / GAS_PER_SECOND;
+				Weight::from_parts(gas_limit.saturating_mul(WEIGHT_PER_GAS), 0)
+					.saturating_add(RocksDbWeight::get().reads(1_u64))
+			},
+			_ => Weight::zero(),
+		}
+	}
+}
+
+pub struct MoonbeamWeights;
+impl MoonbeamWeights {
+	fn descend_origin() -> Weight {
+		Weight::from_parts(5_992_000, 0)
+	}
+
+	fn withdraw_asset() -> Weight {
+		Weight::from_parts(200_000_000, 0)
+	}
+
+	fn buy_execution() -> Weight {
+		Weight::from_parts(181_080_000, 19056).saturating_add(RocksDbWeight::get().reads(4_u64))
+	}
+
+	fn transact() -> Weight {
+		Weight::from_parts(24_375_000, 1527).saturating_add(RocksDbWeight::get().reads(1_u64))
+	}
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,6 +15,7 @@
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::types::{QueryId, Timestamp, U256};
+use frame_support::weights::Weight;
 #[cfg(feature = "runtime-benchmarks")]
 use frame_support::BoundedVec;
 use sp_std::vec::Vec;
@@ -153,4 +154,19 @@ pub trait BenchmarkHelper<AccountId, Balance, MaxQueryDataLength> {
 	/// # Returns
 	/// Bytes of query data
 	fn get_staking_to_local_token_price_query_data() -> BoundedVec<u8, MaxQueryDataLength>;
+}
+
+// From: https://github.com/paritytech/polkadot/blob/b1cc6fa14330261a305d56be36c04e9c99518993/xcm/xcm-executor/src/traits/weight.rs#L34
+/// A means of getting approximate weight consumption for a given destination message executor and a
+/// message.
+pub trait UniversalWeigher {
+	/// Get the upper limit of weight required for `dest` to execute `message`.
+	#[allow(clippy::result_unit_err)]
+	fn weigh(dest: impl Into<MultiLocation>, message: Xcm<()>) -> Result<Weight, ()>;
+}
+
+/// A means of getting approximate weight consumption of a transact instruction
+pub trait Weigher: UniversalWeigher {
+	/// Get the upper limit of weight required for `dest` to execute `transact` instruction
+	fn transact(dest: impl Into<MultiLocation>, gas_limit: u64) -> Weight;
 }

--- a/src/xcm/mod.rs
+++ b/src/xcm/mod.rs
@@ -15,21 +15,21 @@
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
 use super::{traits, Config, Error, Event, Pallet};
-use crate::types::ParaId;
+use crate::{
+	traits::{UniversalWeigher, Weigher},
+	types::ParaId,
+};
 use ::xcm::latest::prelude::*;
 use core::marker::PhantomData;
 use frame_support::{
 	log,
 	pallet_prelude::*,
 	traits::{OriginTrait, PalletInfoAccess},
-	weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 };
 use sp_core::Get;
 use sp_std::{fmt::Debug, vec, vec::Vec};
 use traits::SendXcm;
 use xcm_executor::traits::{Convert, ConvertOrigin};
-
-pub(crate) type DbWeight = frame_support::weights::constants::RocksDbWeight;
 
 pub(crate) mod ethereum_xcm;
 
@@ -131,11 +131,29 @@ impl From<ContractLocation> for MultiLocation {
 /// * `gas_limit` - The gas limit used to calculate the weight and corresponding fees required.
 /// # Returns
 /// A XCM message for remote transact.
-pub(crate) fn transact<T: Config>(call: Vec<u8>, gas_limit: u64) -> Xcm<()> {
+pub(crate) fn transact<T: Config>(call: Vec<u8>, gas_limit: u64, dest: MultiLocation) -> Xcm<()> {
 	// Calculate weight for executing smart contract call via ethereum_xcm::transact(): https://github.com/PureStake/moonbeam/blob/056f67494ccf8f815e33cf350fe0575734b89ec5/pallets/ethereum-xcm/src/lib.rs#L138-L147
-	let transact_extrinsic_weight = gas_to_weight(gas_limit) + DbWeight::get().reads(1);
+	//let transact_extrinsic_weight = gas_to_weight(gas_limit) + DbWeight::get().reads(1);
+	let transact_extrinsic_weight = T::Weigher::transact(dest, gas_limit);
+
+	let message = Xcm(vec![
+		DescendOrigin(Parachain(T::ParachainId::get()).into()),
+		WithdrawAsset((T::XcmFeesAsset::get(), Fungible(1u128)).into()),
+		BuyExecution {
+			fees: (T::XcmFeesAsset::get(), Fungible(1u128)).into(),
+			weight_limit: Limited(Weight::zero()),
+		},
+		Transact {
+			origin_kind: OriginKind::SovereignAccount,
+			require_weight_at_most: Weight::zero(),
+			call: call.clone().into(),
+		},
+	]);
+
+	// Extract weight of XCM message
+	let xcm_weight: Weight = T::Weigher::weigh(dest, message).unwrap();
 	// Calculate total weight based on xcm message weight and transact execution
-	let total_weight = weigh() + transact_extrinsic_weight;
+	let total_weight = xcm_weight + transact_extrinsic_weight;
 	// Convert to fee amount
 	let amount = weight_to_fee::<T>(total_weight);
 	let asset: MultiAsset = (T::XcmFeesAsset::get(), Fungible(amount)).into();
@@ -149,31 +167,6 @@ pub(crate) fn transact<T: Config>(call: Vec<u8>, gas_limit: u64) -> Xcm<()> {
 			call: call.into(),
 		},
 	])
-}
-
-pub(crate) fn gas_to_weight(gas_limit: u64) -> Weight {
-	// https://github.com/PureStake/moonbeam/blob/master/runtime/moonbase/src/lib.rs#L371-L375
-	const GAS_PER_SECOND: u64 = 40_000_000;
-	const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND / GAS_PER_SECOND;
-	Weight::from_parts(gas_limit.saturating_mul(WEIGHT_PER_GAS), 0)
-}
-
-/// The weight of a XCM message.
-pub(crate) fn weigh() -> Weight {
-	// Standard database weight
-	let db_weight = frame_support::weights::constants::RocksDbWeight::get();
-	// Moonbase Alpha benchmarked instruction weights
-	const DESCEND_ORIGIN: Weight = Weight::from_parts(10_084_000, 0); // https://github.com/PureStake/moonbeam/blob/056f67494ccf8f815e33cf350fe0575734b89ec5/pallets/moonbeam-xcm-benchmarks/src/weights/moonbeam_xcm_benchmarks_generic.rs#L169
-	const WITHDRAW_ASSET: Weight = Weight::from_parts(200_000_000, 0); // https://github.com/PureStake/moonbeam/blob/056f67494ccf8f815e33cf350fe0575734b89ec5/pallets/moonbeam-xcm-benchmarks/src/weights/moonbeam_xcm_benchmarks_fungible.rs#L28
-	let buy_execution: Weight =
-		Weight::from_parts(158_702_000, 0).saturating_add(db_weight.reads(4)); // https://github.com/PureStake/moonbeam/blob/056f67494ccf8f815e33cf350fe0575734b89ec5/pallets/moonbeam-xcm-benchmarks/src/weights/moonbeam_xcm_benchmarks_generic.rs#L136
-	let transact: Weight = Weight::from_parts(34_785_000, 0).saturating_add(db_weight.reads(1)); // https://github.com/PureStake/moonbeam/blob/056f67494ccf8f815e33cf350fe0575734b89ec5/pallets/moonbeam-xcm-benchmarks/src/weights/moonbeam_xcm_benchmarks_generic.rs#L148
-
-	// Calculate combined weight of xcm instructions
-	DESCEND_ORIGIN
-		.saturating_add(WITHDRAW_ASSET)
-		.saturating_add(buy_execution)
-		.saturating_add(transact)
 }
 
 pub(crate) fn weight_to_fee<T: Config>(weight: Weight) -> u128 {
@@ -209,6 +202,7 @@ mod tests {
 		types::Address,
 	};
 	use codec::Encode;
+	use frame_support::weights::constants::RocksDbWeight;
 	use sp_core::blake2_256;
 	use std::borrow::Borrow;
 
@@ -278,26 +272,33 @@ mod tests {
 	}
 
 	#[test]
-	fn gas_to_weight() {
-		// https://docs.moonbeam.network/builders/interoperability/xcm/remote-evm-calls/#differences-regular-remote-evm
-		const WEIGHT_PER_GAS: u64 = 25_000;
-		assert_eq!(super::gas_to_weight(1), Weight::from_parts(WEIGHT_PER_GAS, 0));
-		const MAX_GAS_LIMIT: u64 = 720_000;
-		assert_eq!(super::gas_to_weight(MAX_GAS_LIMIT), Weight::from_parts(18_000_000_000, 0));
-	}
-
-	#[test]
 	fn transact() {
 		const GAS_LIMIT: u64 = 100_000;
-		let xt_weight = super::gas_to_weight(GAS_LIMIT) + DbWeight::get().reads(1);
-		let total_weight = super::weigh() + xt_weight;
+		let xt_weight =
+			<Test as crate::Config>::Weigher::transact(Parachain(EVM_PARA_ID), GAS_LIMIT);
+
+		let descend_origin = Weight::from_parts(5_992_000, 0);
+		let withdraw_asset = Weight::from_parts(200_000_000, 0);
+		let buy_execution = Weight::from_parts(181_080_000, 19056)
+			.saturating_add(RocksDbWeight::get().reads(4_u64));
+		let transact =
+			Weight::from_parts(24_375_000, 1527).saturating_add(RocksDbWeight::get().reads(1_u64));
+
+		let weigh = descend_origin
+			.saturating_add(withdraw_asset)
+			.saturating_add(buy_execution)
+			.saturating_add(transact);
+
+		let total_weight = weigh + xt_weight;
+		// Convert to fee amount
+		let amount = super::weight_to_fee::<Test>(total_weight);
 		let fees = MultiAsset {
 			id: Concrete(MultiLocation { parents: 0, interior: X1(PalletInstance(3)) }),
-			fun: Fungible(total_weight.ref_time() as u128 * 50_000),
+			fun: Fungible(amount),
 		};
 
 		assert_eq!(
-			super::transact::<Test>(vec![], GAS_LIMIT),
+			super::transact::<Test>(vec![], GAS_LIMIT, Parachain(EVM_PARA_ID).into()),
 			Xcm(vec![
 				WithdrawAsset(fees.clone().into()),
 				BuyExecution { fees, weight_limit: Limited(total_weight) },
@@ -307,21 +308,6 @@ mod tests {
 					call: vec![].into(),
 				},
 			]),
-		);
-	}
-
-	#[test]
-	fn weigh() {
-		let read = frame_support::weights::constants::RocksDbWeight::get().read;
-		assert_eq!(
-			super::weigh(),
-			Weight::from_parts(
-				10_084_000 + // DescendOrigin
-					200_000_000 + // WithdrawAsset
-					(158_702_000 + read * 4) + // BuyExecution
-					(34_785_000 + 1 * read), // Transact
-				0
-			)
 		);
 	}
 


### PR DESCRIPTION
This PR pertains to adding support for updating weights required on the remote chain over time.

Resolves #120