### PR TITLE
fix: further limit max vote rounds

### DIFF
--- a/src/benchmarking.rs
+++ b/src/benchmarking.rs
@@ -562,7 +562,7 @@ benchmarks! {
 
 	report_vote_executed {
 		// Maximum number of vote rounds are used as this extrinsic iterates over all vote rounds
-		let r in 1..u8::MAX.into();
+		let r in 1..MAX_VOTE_ROUNDS.into();
 		let query_data: QueryDataOf<T> = BoundedVec::try_from(vec![0u8; T::MaxQueryDataLength::get() as usize]).unwrap();
 		let query_id = Keccak256::hash(query_data.as_ref()).into();
 		let reporter = account::<AccountIdOf<T>>("account", 256, SEED);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -30,5 +30,8 @@ pub(super) const MAX_ITERATIONS: u32 = 32;
 /// The maximum number of aggregate votes on disputes sent to the governance controller contract per block.
 pub(super) const MAX_AGGREGATE_VOTES_SENT_PER_BLOCK: u8 = 3;
 
+/// The maximum number of vote rounds per dispute.
+pub const MAX_VOTE_ROUNDS: u8 = 20;
+
 /// Base amount of time before a reporter is able to submit a value again.
 pub(crate) const REPORTING_LOCK: Timestamp = 12 * HOURS;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use crate::{
 	contracts::gas_limits,
 };
 use codec::Encode;
-pub use constants::{DAYS, HOURS, MINUTES, WEEKS};
+pub use constants::{DAYS, HOURS, MAX_VOTE_ROUNDS, MINUTES, WEEKS};
 use frame_support::{
 	dispatch::{DispatchError, DispatchResult},
 	ensure,
@@ -653,7 +653,7 @@ pub mod pallet {
 					.ref_time(),
 				report_stake_withdrawn: T::WeightInfo::report_stake_withdrawn().ref_time(),
 				report_vote_tallied: T::WeightInfo::report_vote_tallied().ref_time(),
-				report_vote_executed: T::WeightInfo::report_vote_executed(u8::MAX.into())
+				report_vote_executed: T::WeightInfo::report_vote_executed(MAX_VOTE_ROUNDS.into())
 					.ref_time(),
 				report_slash: T::WeightInfo::report_slash().ref_time(),
 			};
@@ -1143,6 +1143,9 @@ pub mod pallet {
 				|vote_rounds| -> Result<u8, DispatchError> {
 					*vote_rounds =
 						vote_rounds.checked_add(1).ok_or(Error::<T>::MaxVoteRoundsReached)?;
+					if *vote_rounds > MAX_VOTE_ROUNDS {
+						return Err(Error::<T>::MaxVoteRoundsReached.into())
+					}
 					Ok(*vote_rounds)
 				},
 			)?;
@@ -1591,7 +1594,7 @@ pub mod pallet {
 		///
 		/// - `dispute_id`: The identifier of the dispute.
 		#[pallet::call_index(18)]
-		#[pallet::weight(<T as Config>::WeightInfo::report_vote_executed(u8::MAX.into()))]
+		#[pallet::weight(<T as Config>::WeightInfo::report_vote_executed(MAX_VOTE_ROUNDS.into()))]
 		pub fn report_vote_executed(
 			origin: OriginFor<T>,
 			dispute_id: DisputeId,

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -535,8 +535,8 @@ fn begin_dispute_round_fee_saturates() {
 		let dispute_id = dispute_id(PARA_ID, query_id, timestamp);
 		println!("{}", Tellor::get_vote_info(dispute_id, 1).unwrap().fee / 10u128.pow(12));
 
-		// Repeatedly start new vote rounds until reaching vote_round::MAAX
-		for round in 2..u8::MAX {
+		// Repeatedly start new vote rounds until reaching MAX_VOTE_ROUNDS
+		for round in 2..=MAX_VOTE_ROUNDS {
 			// Wait max time period before tally
 			with_block_after(6 * DAYS, || {
 				assert_ok!(Tellor::report_vote_tallied(
@@ -557,6 +557,15 @@ fn begin_dispute_round_fee_saturates() {
 				);
 			});
 		}
+		assert_noop!(
+			Tellor::begin_dispute(
+				RuntimeOrigin::signed(disputer),
+				query_id,
+				timestamp,
+				Some(disputer_address),
+			),
+			Error::MaxVoteRoundsReached
+		);
 	});
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,7 +15,7 @@
 // along with Tellor. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	constants::DECIMALS,
+	constants::{DECIMALS, MAX_VOTE_ROUNDS},
 	contracts::{gas_limits, registry},
 	mock,
 	mock::*,
@@ -245,7 +245,7 @@ fn registers() {
 				report_vote_tallied: <Test as crate::Config>::WeightInfo::report_vote_tallied()
 					.ref_time(),
 				report_vote_executed: <Test as crate::Config>::WeightInfo::report_vote_executed(
-					u8::MAX.into(),
+					MAX_VOTE_ROUNDS.into(),
 				)
 				.ref_time(),
 				report_slash: <Test as crate::Config>::WeightInfo::report_slash().ref_time(),

--- a/src/tests/weights.rs
+++ b/src/tests/weights.rs
@@ -1,12 +1,16 @@
 use crate::{
-	constants::{MAX_AGGREGATE_VOTES_SENT_PER_BLOCK, MAX_ITERATIONS},
+	constants::{MAX_AGGREGATE_VOTES_SENT_PER_BLOCK, MAX_ITERATIONS, MAX_VOTE_ROUNDS},
 	mock::Test,
 	Config, WeightInfo,
 };
 use frame_support::{
 	pallet_prelude::Get,
-	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
+	weights::{
+		constants::{WEIGHT_REF_TIME_PER_NANOS, WEIGHT_REF_TIME_PER_SECOND},
+		Weight,
+	},
 };
+use sp_runtime::Perbill;
 
 type MaxClaimTimestamps = <Test as Config>::MaxClaimTimestamps;
 type MaxDisputedTimeSeries = <Test as Config>::MaxDisputedTimeSeries;
@@ -15,32 +19,61 @@ type MaxValueLength = <Test as Config>::MaxValueLength;
 type MaxVotes = <Test as Config>::MaxVotes;
 type Weights = <Test as Config>::WeightInfo;
 
-const MAX_REF_TIME: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(2); // https://github.com/paritytech/cumulus/blob/98e68bd54257b4039a5d5b734816f4a1b7c83a9d/parachain-template/runtime/src/lib.rs#L221
-const MAX_POV_SIZE: u64 = 5 * 1024 * 1024; // https://github.com/paritytech/polkadot/blob/ba1f65493d91d4ab1787af2fd6fe880f1da90586/primitives/src/v4/mod.rs#L384
-const MAX_WEIGHT: Weight = Weight::from_parts(MAX_REF_TIME, MAX_POV_SIZE);
+// max block: 0.5s compute with 12s average block time
+const MAX_BLOCK_REF_TIME: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(2); // https://github.com/paritytech/cumulus/blob/98e68bd54257b4039a5d5b734816f4a1b7c83a9d/parachain-template/runtime/src/lib.rs#L221
+const MAX_BLOCK_POV_SIZE: u64 = 5 * 1024 * 1024; // https://github.com/paritytech/polkadot/blob/ba1f65493d91d4ab1787af2fd6fe880f1da90586/primitives/src/v4/mod.rs#L384
+const MAX_BLOCK_WEIGHT: Weight = Weight::from_parts(MAX_BLOCK_REF_TIME, MAX_BLOCK_POV_SIZE);
+// max extrinsics: 75% of block
+const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75); // https://github.com/paritytech/cumulus/blob/d20c4283fe85df0c1ef8cb7c9eb7c09abbcbfa31/parachain-template/runtime/src/lib.rs#L218
+
+// xcm-transactor limit
+const DEFAULT_PROOF_SIZE: u64 = 256 * 1024; // https://github.com/PureStake/moonbeam/blob/a51b9570daedeb28853a8f730379a37fd977a487/primitives/xcm/src/ethereum_xcm.rs#L34
+const TRANSACT_REQUIRED_WEIGHT_AT_MOST_PROOF_SIZE: u64 = DEFAULT_PROOF_SIZE / 2; // https://github.com/PureStake/moonbeam/blob/a51b9570daedeb28853a8f730379a37fd977a487/precompiles/xcm-transactor/src/functions.rs#L392
 
 #[test]
 fn verify() {
-	for (function, weight) in vec![
-		("register", Weights::register()),
-		("claim_onetime_tip", Weights::claim_onetime_tip(MaxClaimTimestamps::get())),
-		("claim_tip", Weights::claim_tip(MaxClaimTimestamps::get())),
-		("fund_feed", Weights::fund_feed()),
-		("setup_data_feed", Weights::setup_data_feed(MaxQueryDataLength::get())),
-		("tip", Weights::tip(MaxQueryDataLength::get())),
-		("add_staking_rewards", Weights::add_staking_rewards()),
-		("submit_value", Weights::submit_value(MaxQueryDataLength::get(), MaxValueLength::get())),
-		("update_stake_amount", Weights::update_stake_amount(MAX_ITERATIONS, MAX_ITERATIONS)),
-		("begin_dispute", Weights::begin_dispute(MaxDisputedTimeSeries::get())),
-		("vote", Weights::vote()),
-		("vote_on_multiple_disputes", Weights::vote_on_multiple_disputes(MaxVotes::get())),
-		("send_votes", Weights::send_votes(u8::MAX.into())),
-		("report_stake_deposited", Weights::report_stake_deposited()),
-		("report_staking_withdraw_request", Weights::report_staking_withdraw_request()),
-		("report_stake_withdrawn", Weights::report_stake_withdrawn()),
-		("report_slash", Weights::report_slash()),
-		("report_vote_tallied", Weights::report_vote_tallied()),
-		("report_vote_executed", Weights::report_vote_executed(u8::MAX.into())),
+	let max_total_extrinsics = MAX_BLOCK_WEIGHT * NORMAL_DISPATCH_RATIO;
+	// max extrinsic: max total extrinsics less average on_initialize ratio and less base extrinsic weight
+	const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5); // https://github.com/paritytech/cumulus/blob/d20c4283fe85df0c1ef8cb7c9eb7c09abbcbfa31/parachain-template/runtime/src/lib.rs#L214
+	const BASE_EXTRINSIC: Weight =
+		Weight::from_parts(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0); // https://github.com/paritytech/cumulus/blob/d20c4283fe85df0c1ef8cb7c9eb7c09abbcbfa31/parachain-template/runtime/src/weights/extrinsic_weights.rs#L26
+	let max_extrinsic_weight = max_total_extrinsics
+		.saturating_sub(MAX_BLOCK_WEIGHT * AVERAGE_ON_INITIALIZE_RATIO)
+		.saturating_sub(BASE_EXTRINSIC);
+	assert_eq!(max_extrinsic_weight, Weight::from_parts(349_875_000_000, 3_670_016));
+
+	println!("max block weight: {MAX_BLOCK_WEIGHT}");
+	println!("max total extrinsics weight: {max_total_extrinsics}");
+	println!("max extrinsic weight: {max_extrinsic_weight}\n");
+
+	for (function, weight, check_proof_size_limit) in vec![
+		("register", Weights::register(), false),
+		("claim_onetime_tip", Weights::claim_onetime_tip(MaxClaimTimestamps::get()), false),
+		("claim_tip", Weights::claim_tip(MaxClaimTimestamps::get()), false),
+		("fund_feed", Weights::fund_feed(), false),
+		("setup_data_feed", Weights::setup_data_feed(MaxQueryDataLength::get()), false),
+		("tip", Weights::tip(MaxQueryDataLength::get()), false),
+		("add_staking_rewards", Weights::add_staking_rewards(), false),
+		(
+			"submit_value",
+			Weights::submit_value(MaxQueryDataLength::get(), MaxValueLength::get()),
+			false,
+		),
+		(
+			"update_stake_amount",
+			Weights::update_stake_amount(MAX_ITERATIONS, MAX_ITERATIONS),
+			false,
+		),
+		("begin_dispute", Weights::begin_dispute(MaxDisputedTimeSeries::get()), false),
+		("vote", Weights::vote(), false),
+		("vote_on_multiple_disputes", Weights::vote_on_multiple_disputes(MaxVotes::get()), false),
+		("send_votes", Weights::send_votes(u8::MAX.into()), false),
+		("report_stake_deposited", Weights::report_stake_deposited(), true),
+		("report_staking_withdraw_request", Weights::report_staking_withdraw_request(), true),
+		("report_stake_withdrawn", Weights::report_stake_withdrawn(), true),
+		("report_slash", Weights::report_slash(), true),
+		("report_vote_tallied", Weights::report_vote_tallied(), true),
+		("report_vote_executed", Weights::report_vote_executed(MAX_VOTE_ROUNDS.into()), true),
 		(
 			"on_initialize",
 			Weights::on_initialize(
@@ -48,13 +81,30 @@ fn verify() {
 				MAX_ITERATIONS,
 				MAX_AGGREGATE_VOTES_SENT_PER_BLOCK.into(),
 			),
+			false,
 		),
 	] {
+		println!("{function}: {weight:?}",);
 		println!(
-			"{function}: max {weight:?}\t{:.2}% max ref_time, {:.2}% max proof_size",
-			(weight.ref_time() as f64 / MAX_WEIGHT.ref_time() as f64) * 100.0,
-			(weight.proof_size() as f64 / MAX_WEIGHT.proof_size() as f64) * 100.0
+			"\tpercentage of max extrinsic weight: {:.2}% (ref_time), {:.2}% (proof_size)",
+			(weight.ref_time() as f64 / max_extrinsic_weight.ref_time() as f64) * 100.0,
+			(weight.proof_size() as f64 / max_extrinsic_weight.proof_size() as f64) * 100.0,
 		);
-		assert!(weight.all_lt(MAX_WEIGHT));
+		println!(
+			"\tmax tx per block: {} (ref_time), {} (proof_size)",
+			max_extrinsic_weight.ref_time() / weight.ref_time(),
+			max_extrinsic_weight.proof_size() / weight.proof_size()
+		);
+		assert!(weight.all_lt(max_extrinsic_weight));
+
+		// ensure max proof size within xcm-transactor limit
+		if check_proof_size_limit {
+			assert!(
+				weight.proof_size() <= TRANSACT_REQUIRED_WEIGHT_AT_MOST_PROOF_SIZE,
+				"{function} weight proof_size of {} is greater than the xcm-transactor transact proof limit of {}",
+				weight.proof_size(),
+				TRANSACT_REQUIRED_WEIGHT_AT_MOST_PROOF_SIZE
+			);
+		}
 	}
 }

--- a/src/tests/weights.rs
+++ b/src/tests/weights.rs
@@ -1,3 +1,19 @@
+// Copyright 2023 Tellor Inc.
+// This file is part of Tellor.
+
+// Tellor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tellor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tellor. If not, see <http://www.gnu.org/licenses/>.
+
 use crate::{
 	constants::{MAX_AGGREGATE_VOTES_SENT_PER_BLOCK, MAX_ITERATIONS, MAX_VOTE_ROUNDS},
 	mock::Test,


### PR DESCRIPTION
Required as xcm_transactor transact calls from evm parachain have a static `weight.proof_size` limit ([ref](https://github.com/PureStake/moonbeam/blob/ebb50badabea6021e3f593b19eecd3d84805ce49/precompiles/xcm-transactor/src/functions.rs#L355)), requiring the max `weight.proof_size` of `report_vote_executed` to function within that limit.

https://github.com/PureStake/moonbeam/blob/ebb50badabea6021e3f593b19eecd3d84805ce49/precompiles/xcm-transactor/src/functions.rs#L171 also implies that this may change in the future.

Adds checks for this in the `tests/weights/verify` test.