### PR TITLE
fix: externalize config of ethereum-xcm pallet index on destination chain

### DIFF
--- a/runtime-api/src/tests.rs
+++ b/runtime-api/src/tests.rs
@@ -116,6 +116,7 @@ impl tellor::Config for Test {
 	type Asset = Balances;
 	type Balance = Balance;
 	type Decimals = ();
+	type EthereumXcmPalletIndex = ();
 	type Fee = ();
 	type FeeLocation = FeeLocation;
 	type Governance = ();

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -272,6 +272,7 @@ impl<T: Config> Pallet<T> {
 				let message = xcm::transact::<T>(
 					Parachain(governance_contract.para_id),
 					xcm::ethereum_xcm::transact(
+						T::EthereumXcmPalletIndex::get(),
 						governance_contract.address,
 						contracts::governance::vote(
 							dispute_id.as_ref(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,119 +105,91 @@ pub mod pallet {
 	pub trait Config: frame_system::Config {
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
 		/// The runtime origin type.
 		type RuntimeOrigin: From<<Self as frame_system::Config>::RuntimeOrigin>
 			+ Into<result::Result<Origin, <Self as Config>::RuntimeOrigin>>;
-
 		/// The fungible asset used for tips, dispute fees and staking rewards.
 		type Asset: Inspect<Self::AccountId, Balance = Self::Balance> + Transfer<Self::AccountId>;
-
 		/// The units in which we record balances.
 		type Balance: Balance + From<Timestamp> + From<u128> + Into<U256>;
-
 		/// The number of decimals used by the balance unit.
 		#[pallet::constant]
 		type Decimals: Get<u8>;
-
+		/// The index of the `pallet-ethereum-xcm` pallet within the destination chain runtime.
+		#[pallet::constant]
+		type EthereumXcmPalletIndex: Get<u8>;
 		/// Percentage, 1000 is 100%, 50 is 5%, etc
 		#[pallet::constant]
 		type Fee: Get<u16>;
-
 		/// The (interior) fee location to be used by controller contracts for XCM execution on this parachain.
 		type FeeLocation: Get<InteriorMultiLocation>;
-
 		/// The location of the governance controller contract.
 		#[pallet::constant]
 		type Governance: Get<ContractLocation>;
-
 		/// Origin that handles dispute resolution (governance).
 		type GovernanceOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
-
 		/// Initial dispute fee.
 		#[pallet::constant]
 		type InitialDisputeFee: Get<BalanceOf<Self>>;
-
 		/// The maximum number of timestamps per claim.
 		#[pallet::constant]
 		type MaxClaimTimestamps: Get<u32>;
-
 		/// The maximum number of sequential disputed timestamps.
 		#[pallet::constant]
 		type MaxDisputedTimeSeries: Get<u32>;
-
 		/// The maximum length of query data.
 		#[pallet::constant]
 		type MaxQueryDataLength: Get<u32>;
-
 		/// The maximum length of an individual value submitted to the oracle.
 		#[pallet::constant]
 		type MaxValueLength: Get<u32>;
-
 		/// The maximum number of votes when voting on multiple disputes.
 		#[pallet::constant]
 		type MaxVotes: Get<u32>;
-
 		/// The minimum amount of tokens required to stake.
 		#[pallet::constant]
 		type MinimumStakeAmount: Get<u128>;
-
 		/// The identifier of the pallet within the runtime.
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
-
 		/// The local parachain's own identifier.
 		#[pallet::constant]
 		type ParachainId: Get<ParaId>;
-
 		/// Origin that manages registration with the controller contracts.
 		type RegisterOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
-
 		/// The location of the registry controller contract.
 		#[pallet::constant]
 		type Registry: Get<ContractLocation>;
-
 		// Amount required to be a staker, in the currency as specified in the staking token price query identifier.
 		#[pallet::constant]
 		type StakeAmountCurrencyTarget: Get<u128>;
-
 		/// The location of the staking controller contract.
 		#[pallet::constant]
 		type Staking: Get<ContractLocation>;
-
 		/// Origin that handles staking.
 		type StakingOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
-
 		/// Staking token 'SpotPrice' query identifier, used for updating stake amount.
 		#[pallet::constant]
 		type StakingTokenPriceQueryId: Get<QueryId>;
-
 		/// Staking token to local token 'SpotPrice' query identifier, used for updating dispute fee.
 		#[pallet::constant]
 		type StakingToLocalTokenPriceQueryId: Get<QueryId>;
-
 		/// The on-chain time provider.
 		type Time: UnixTime;
-
 		/// Frequency of stake amount updates.
 		#[pallet::constant]
 		type UpdateStakeAmountInterval: Get<Timestamp>;
-
 		/// The value to convert weight to fee, used by sent to controller contracts to
 		/// calculate fees required for XCM execution on this parachain.
 		#[pallet::constant]
 		type WeightToFee: Get<u128>;
-
 		/// The sub-system used for sending XCM messages.
 		type Xcm: traits::SendXcm;
-
 		/// The asset to be used for fee payment for remote execution on the controller contract chain.
 		type XcmFeesAsset: Get<AssetId>;
-
 		/// The amount per weight unit in the asset used for fee payment for remote execution on the controller contract chain.
 		#[pallet::constant]
 		type XcmWeightToAsset: Get<u128>;
-
 		/// Helper trait for benchmarks.
 		#[cfg(feature = "runtime-benchmarks")]
 		type BenchmarkHelper: BenchmarkHelper<
@@ -225,10 +197,8 @@ pub mod pallet {
 			Self::Balance,
 			Self::MaxQueryDataLength,
 		>;
-
-		/// Means of measuring the weight consumed by an XCM message on destination chain(s)
+		/// Means of measuring the weight consumed by an XCM message on destination chain(s).
 		type Weigher: Weigher;
-
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}
@@ -660,6 +630,7 @@ pub mod pallet {
 			let message = xcm::transact::<T>(
 				Parachain(registry_contract.para_id),
 				ethereum_xcm::transact(
+					T::EthereumXcmPalletIndex::get(),
 					registry_contract.address,
 					registry::register(
 						T::ParachainId::get(),
@@ -1244,6 +1215,7 @@ pub mod pallet {
 			let message = xcm::transact::<T>(
 				Parachain(governance_contract.para_id),
 				ethereum_xcm::transact(
+					T::EthereumXcmPalletIndex::get(),
 					governance_contract.address,
 					governance::begin_parachain_dispute(
 						query_id.as_ref(),
@@ -1421,6 +1393,7 @@ pub mod pallet {
 			let message = xcm::transact::<T>(
 				Parachain(staking_contract.para_id),
 				ethereum_xcm::transact(
+					T::EthereumXcmPalletIndex::get(),
 					staking_contract.address,
 					staking::confirm_parachain_stake_withdraw_request(address, amount)
 						.try_into()

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -139,6 +139,7 @@ impl tellor::Config for Test {
 	type Asset = Balances;
 	type Balance = Balance;
 	type Decimals = ConstU8<12>;
+	type EthereumXcmPalletIndex = ConstU8<38>;
 	type Fee = ConstU16<10>; // 1%
 	type FeeLocation = FeeLocation;
 	type Governance = TellorGovernance;

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -377,6 +377,7 @@ fn begins_dispute_xcm() {
 				sent_xcm(),
 				vec![xcm_transact(
 					ethereum_xcm::transact(
+						EthereumXcmPalletIndex::get(),
 						*GOVERNANCE,
 						contracts::governance::begin_parachain_dispute(
 							query_id.as_ref(),
@@ -1006,6 +1007,7 @@ fn send_votes() {
 						sent_xcm.pop_front().unwrap(),
 						xcm_transact(
 							ethereum_xcm::transact(
+								EthereumXcmPalletIndex::get(),
 								*GOVERNANCE,
 								contracts::governance::vote(
 									dispute_id.as_ref(),
@@ -1131,6 +1133,7 @@ fn send_votes_via_hook() {
 						sent_xcm.pop_front().unwrap(),
 						xcm_transact(
 							ethereum_xcm::transact(
+								EthereumXcmPalletIndex::get(),
 								*GOVERNANCE,
 								contracts::governance::vote(
 									dispute_id.as_ref(),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -50,6 +50,7 @@ mod weights;
 
 type Balance = <Test as crate::Config>::Balance;
 type Error = crate::Error<Test>;
+type EthereumXcmPalletIndex = <Test as crate::Config>::EthereumXcmPalletIndex;
 type U256ToBalance = crate::types::U256ToBalance<Test>;
 
 const MINIMUM_STAKE_AMOUNT: u128 = 100 * TRB;
@@ -256,6 +257,7 @@ fn registers() {
 				sent_xcm(),
 				vec![xcm_transact(
 					ethereum_xcm::transact(
+						EthereumXcmPalletIndex::get(),
 						*REGISTRY,
 						registry::register(
 							PARA_ID,

--- a/src/xcm/ethereum_xcm.rs
+++ b/src/xcm/ethereum_xcm.rs
@@ -22,14 +22,6 @@ use sp_std::vec::Vec;
 /// Max. allowed size of 65_536 bytes.
 pub(crate) const MAX_ETHEREUM_XCM_INPUT_SIZE: u32 = 2u32.pow(16);
 
-// The fixed index of `pallet-ethereum-xcm` within various runtimes.
-#[derive(Clone, Eq, PartialEq, Encode)]
-#[allow(dead_code)]
-pub enum EthereumXcm {
-	#[codec(index = 38u8)]
-	Moonbase(EthereumXcmCall),
-}
-
 // The fixed index of calls available within `pallet-ethereum-xcm`.
 #[derive(Clone, Eq, PartialEq, Encode)]
 #[allow(dead_code)]
@@ -100,11 +92,12 @@ pub enum TransactionAction {
 }
 
 pub(crate) fn transact(
+	pallet_index: u8,
 	contract_address: impl Into<H160>,
 	call_data: BoundedVec<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>,
 	gas_limit: impl Into<U256>,
 ) -> Vec<u8> {
-	EthereumXcm::Moonbase(EthereumXcmCall::Transact {
+	let mut encoded = EthereumXcmCall::Transact {
 		xcm_transaction: EthereumXcmTransaction::V2(EthereumXcmTransactionV2 {
 			gas_limit: gas_limit.into(),
 			action: TransactionAction::Call(contract_address.into()),
@@ -112,8 +105,11 @@ pub(crate) fn transact(
 			input: call_data,
 			access_list: None,
 		}),
-	})
-	.encode()
+	}
+	.encode();
+	// Prepend index of `pallet-ethereum-xcm` pallet within destination chain runtime
+	encoded.insert(0, pallet_index);
+	encoded
 }
 
 #[cfg(test)]
@@ -126,7 +122,7 @@ pub(crate) mod tests {
 		let contract_address: H160 =
 			H160::from_slice(&from_hex("0xa72f549a1a12b9b49f30a7f3aeb1f4e96389c5d8").unwrap());
 		let evm_call_data = from_hex("0xd09de08a").unwrap().try_into().unwrap();
-		let call = transact(contract_address, evm_call_data, 71_000);
+		let call = transact(38, contract_address, evm_call_data, 71_000);
 		assert_eq!(from_hex("0x260001581501000000000000000000000000000000000000000000000000000000000000a72f549a1a12b9b49f30a7f3aeb1f4e96389c5d8000000000000000000000000000000000000000000000000000000000000000010d09de08a00").unwrap(),
                    call);
 	}


### PR DESCRIPTION
Externalizes the pallet index of the Ethereum-Xcm pallet in the destination chain runtime, so that the pallet can easily be configured for use with different runtimes/networks (e.g. Moonbase has the pallet configured at index 38 whereas Moonbeam/Moonriver have it at 109).

Also enables usage with any other evm parachain which adds the ethereum-xcm pallet to their runtime in the future.

Closes #115 