### PR TITLE
fix: optimise weights

### DIFF
--- a/src/tests/autopay.rs
+++ b/src/tests/autopay.rs
@@ -30,6 +30,7 @@ use sp_runtime::traits::{BadOrigin, Convert};
 type Fee = <Test as Config>::Fee;
 type FeedsWithFunding = crate::pallet::FeedsWithFunding<Test>;
 type Tips = crate::pallet::Tips<Test>;
+type Weights = <Test as Config>::WeightInfo;
 
 #[test]
 fn claim_tip_ensures() {
@@ -148,7 +149,7 @@ fn claim_tip_ensures() {
 					query_id,
 					bounded_vec![]
 				),
-				Error::InvalidFeed
+				Error::InvalidFeed.with_weight(Weights::claim_tip(0))
 			);
 			// no tips submitted for this queryId
 			assert_noop!(
@@ -158,7 +159,7 @@ fn claim_tip_ensures() {
 					query_id,
 					bounded_vec![12345.into()]
 				),
-				Error::InsufficientFeedBalance
+				Error::InsufficientFeedBalance.with_weight(Weights::claim_tip(0))
 			);
 			assert_ok!(Tellor::fund_feed(
 				RuntimeOrigin::signed(feed_creator),
@@ -174,7 +175,7 @@ fn claim_tip_ensures() {
 					query_id,
 					timestamps.clone()
 				),
-				Error::ClaimBufferNotPassed
+				Error::ClaimBufferNotPassed.with_weight(Weights::claim_tip(3))
 			);
 		});
 		// Advancing time 12 hours to satisfy hardcoded buffer time.
@@ -187,7 +188,7 @@ fn claim_tip_ensures() {
 					query_id,
 					bad_timestamps
 				),
-				Error::InvalidClaimer
+				Error::InvalidClaimer.with_weight(Weights::claim_tip(1))
 			);
 			assert_noop!(
 				Tellor::claim_tip(
@@ -196,7 +197,7 @@ fn claim_tip_ensures() {
 					query_id,
 					timestamps.clone()
 				),
-				Error::InvalidClaimer
+				Error::InvalidClaimer.with_weight(Weights::claim_tip(1))
 			);
 			// reward already claimed
 			assert_ok!(Tellor::claim_tip(
@@ -212,7 +213,7 @@ fn claim_tip_ensures() {
 					query_id,
 					bounded_vec![claimed.into()]
 				),
-				Error::TipAlreadyClaimed
+				Error::TipAlreadyClaimed.with_weight(Weights::claim_tip(1))
 			);
 		});
 		// no value exists at timestamp
@@ -243,7 +244,7 @@ fn claim_tip_ensures() {
 					query_id,
 					bounded_vec![timestamp.into()]
 				),
-				Error::ValueDisputed
+				Error::ValueDisputed.with_weight(Weights::claim_tip(1))
 			);
 		});
 		// price threshold not met
@@ -288,7 +289,7 @@ fn claim_tip_ensures() {
 					query_id,
 					bounded_vec![timestamp.into()]
 				),
-				Error::PriceThresholdNotMet
+				Error::PriceThresholdNotMet.with_weight(Weights::claim_tip(1))
 			);
 		});
 		// insufficient balance for all submitted timestamps
@@ -317,7 +318,7 @@ fn claim_tip_ensures() {
 					query_id,
 					bounded_vec![timestamp_1.into(), now().into()]
 				),
-				Error::InsufficientFeedBalance
+				Error::InsufficientFeedBalance.with_weight(Weights::claim_tip(1))
 			);
 			now()
 		});
@@ -330,7 +331,7 @@ fn claim_tip_ensures() {
 					query_id,
 					bounded_vec![timestamp_2.into()]
 				),
-				Error::ClaimPeriodExpired
+				Error::ClaimPeriodExpired.with_weight(Weights::claim_tip(1))
 			);
 		});
 	});
@@ -985,7 +986,7 @@ fn claim_onetime_tip() {
 		// no tips submitted for this queryId
 		assert_noop!(
 			Tellor::claim_onetime_tip(RuntimeOrigin::signed(reporter), query_id, bounded_vec![]),
-			Error::NoTipsSubmitted
+			Error::NoTipsSubmitted.with_weight(Weights::claim_onetime_tip(0))
 		);
 
 		// buffer time has not passed
@@ -1015,7 +1016,7 @@ fn claim_onetime_tip() {
 					query_id,
 					bounded_vec![timestamp.into()]
 				),
-				Error::ClaimBufferNotPassed
+				Error::ClaimBufferNotPassed.with_weight(Weights::claim_onetime_tip(1))
 			);
 		});
 		with_block_after(86_400 / 2, || {
@@ -1059,7 +1060,7 @@ fn claim_onetime_tip() {
 					query_id,
 					bounded_vec![timestamp.into()]
 				),
-				Error::ValueDisputed
+				Error::ValueDisputed.with_weight(Weights::claim_onetime_tip(1))
 			);
 		});
 
@@ -1087,7 +1088,7 @@ fn claim_onetime_tip() {
 					query_id,
 					bounded_vec![timestamp.into()]
 				),
-				Error::InvalidClaimer
+				Error::InvalidClaimer.with_weight(Weights::claim_onetime_tip(1))
 			);
 		});
 
@@ -1127,7 +1128,7 @@ fn claim_onetime_tip() {
 					query_id,
 					bounded_vec![timestamp_2.into()]
 				),
-				Error::TipAlreadyEarned
+				Error::TipAlreadyEarned.with_weight(Weights::claim_onetime_tip(1))
 			);
 		});
 		with_block(|| {
@@ -1176,7 +1177,7 @@ fn claim_onetime_tip() {
 					query_id,
 					bounded_vec![timestamp_1.into()]
 				),
-				Error::TimestampIneligibleForTip
+				Error::TimestampIneligibleForTip.with_weight(Weights::claim_onetime_tip(1))
 			);
 			assert_ok!(Tellor::claim_onetime_tip(
 				RuntimeOrigin::signed(another_reporter),
@@ -1191,7 +1192,7 @@ fn claim_onetime_tip() {
 					query_id,
 					bounded_vec![timestamp_2.into()]
 				),
-				Error::TipAlreadyClaimed
+				Error::TipAlreadyClaimed.with_weight(Weights::claim_onetime_tip(1))
 			);
 		});
 	});

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -29,6 +29,7 @@ type PendingVotes = crate::pallet::PendingVotes<Test>;
 type VoteInfo = crate::pallet::VoteInfo<Test>;
 type VoteRounds = crate::pallet::VoteRounds<Test>;
 type Votes = crate::Votes<Test>;
+type Weights = <Test as Config>::WeightInfo;
 
 #[test]
 fn begin_dispute() {
@@ -52,7 +53,7 @@ fn begin_dispute() {
 			);
 			assert_noop!(
 				Tellor::begin_dispute(RuntimeOrigin::signed(another_reporter), query_id, 0, None),
-				Error::NotReporter
+				Error::NotReporter.with_weight(Weights::begin_dispute(0))
 			);
 
 			assert_ok!(Tellor::report_stake_deposited(
@@ -63,7 +64,7 @@ fn begin_dispute() {
 			));
 			assert_noop!(
 				Tellor::begin_dispute(RuntimeOrigin::signed(another_reporter), query_id, 0, None),
-				Error::NoValueExists
+				Error::NoValueExists.with_weight(Weights::begin_dispute(0))
 			);
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
@@ -158,7 +159,7 @@ fn begin_dispute() {
 					timestamp,
 					None
 				),
-				Error::DisputeRoundReportingPeriodExpired
+				Error::DisputeRoundReportingPeriodExpired.with_weight(Weights::begin_dispute(0))
 			); //assert second dispute started within a day
 
 			assert_ok!(Tellor::report_stake_deposited(
@@ -185,7 +186,7 @@ fn begin_dispute() {
 					timestamp,
 					None
 				),
-				Error::DisputeReportingPeriodExpired
+				Error::DisputeReportingPeriodExpired.with_weight(Weights::begin_dispute(0))
 			); //dispute must be started within timeframe
 		})
 	});
@@ -220,7 +221,7 @@ fn begin_dispute_by_non_reporter() {
 					0,
 					Some(oracle_user)
 				),
-				Error::NoValueExists
+				Error::NoValueExists.with_weight(Weights::begin_dispute(0))
 			);
 			assert_ok!(Tellor::submit_value(
 				RuntimeOrigin::signed(reporter),
@@ -313,7 +314,7 @@ fn begin_dispute_by_non_reporter() {
 					timestamp,
 					Some(oracle_user)
 				),
-				Error::DisputeRoundReportingPeriodExpired
+				Error::DisputeRoundReportingPeriodExpired.with_weight(Weights::begin_dispute(0))
 			); //assert second dispute started within a day
 
 			assert_ok!(Tellor::report_stake_deposited(
@@ -340,7 +341,7 @@ fn begin_dispute_by_non_reporter() {
 					timestamp,
 					Some(oracle_user)
 				),
-				Error::DisputeReportingPeriodExpired
+				Error::DisputeReportingPeriodExpired.with_weight(Weights::begin_dispute(0))
 			); //dispute must be started within timeframe
 		})
 	});
@@ -446,7 +447,7 @@ fn begin_dispute_checks_max_vote_rounds() {
 			Balances::make_free_balance_be(&reporter, token(10));
 			assert_noop!(
 				Tellor::begin_dispute(RuntimeOrigin::signed(reporter), query_id, timestamp, None),
-				Error::MaxVoteRoundsReached
+				Error::MaxVoteRoundsReached.with_weight(Weights::begin_dispute(0))
 			);
 		});
 	});
@@ -565,7 +566,7 @@ fn begin_dispute_round_fee_saturates() {
 				timestamp,
 				Some(disputer_address),
 			),
-			Error::MaxVoteRoundsReached
+			Error::MaxVoteRoundsReached.with_weight(Weights::begin_dispute(0))
 		);
 	});
 }
@@ -683,7 +684,7 @@ fn execute_vote() {
 					timestamp_1,
 					None
 				),
-				Error::DisputeRoundReportingPeriodExpired
+				Error::DisputeRoundReportingPeriodExpired.with_weight(Weights::begin_dispute(0))
 			); // assert second dispute started within a day
 
 			let vote = Tellor::get_vote_info(dispute_1, 1).unwrap();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -31,6 +31,7 @@ use crate::{
 use ethabi::{Bytes, Token, Uint};
 use frame_support::{
 	assert_noop, assert_ok,
+	dispatch::WithPostDispatchInfo,
 	traits::{Get, UnixTime},
 	weights::Weight,
 };

--- a/src/tests/using_tellor.rs
+++ b/src/tests/using_tellor.rs
@@ -332,6 +332,7 @@ fn is_in_dispute() {
 					None
 				),
 				Error::DisputeRoundReportingPeriodExpired
+					.with_weight(<Test as crate::Config>::WeightInfo::begin_dispute(0))
 			);
 			assert!(Tellor::is_in_dispute(query_id, timestamp_1));
 


### PR DESCRIPTION
Uses corresponding parameter values in pre-dispatch weight calculation when possible. Includes weight info when an error occurs for weight refund (only for weight functions with complexity parameter).

Closes #127 