### PR TITLE
feat: allow optional gas limit when registering

### DIFF
--- a/src/benchmarking.rs
+++ b/src/benchmarking.rs
@@ -122,7 +122,7 @@ fn dispute_id(para_id: u32, query_id: QueryId, timestamp: Timestamp) -> DisputeI
 benchmarks! {
 	register {
 		T::BenchmarkHelper::set_balance(Tellor::<T>::account(), token::<T>(1u8));
-	}: _(RawOrigin::Root)
+	}: _(RawOrigin::Root, None)
 
 	claim_onetime_tip {
 		// Maximum timestamps for claiming tip for measuring maximum weight
@@ -568,7 +568,7 @@ benchmarks! {
 		let caller = T::GovernanceOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 		let address = Address::zero();
 		T::BenchmarkHelper::set_balance(Tellor::<T>::account(), token::<T>(1u8));
-		Tellor::<T>::register(RawOrigin::Root.into())?;
+		Tellor::<T>::register(RawOrigin::Root.into(), None)?;
 		deposit_stake::<T>(reporter.clone(), trb(1_200), address)?;
 		T::BenchmarkHelper::set_time(HOURS);
 		Tellor::<T>::submit_value(

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -33,7 +33,7 @@ fn call(function: &[u8; 4], mut parameters: Vec<u8>) -> Vec<u8> {
 pub(crate) mod gas_limits {
 	// Static gas limits, based on max gas from `forge test --gas-report` of contracts
 	pub(crate) const BEGIN_PARACHAIN_DISPUTE: u64 = 600_000;
-	pub(crate) const REGISTER: u64 = 250_000;
+	pub(crate) const REGISTER: u64 = 400_000;
 	pub(crate) const VOTE: u64 = 150_000;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,7 +604,7 @@ pub mod pallet {
 		/// Registers the parachain with the Tellor controller contracts.
 		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::register())]
-		pub fn register(origin: OriginFor<T>) -> DispatchResult {
+		pub fn register(origin: OriginFor<T>, gas_limit: Option<u64>) -> DispatchResult {
 			T::RegisterOrigin::ensure_origin(origin)?;
 			// Initialize sub-accounts
 			let min_balance = T::Asset::minimum_balance();
@@ -616,7 +616,7 @@ pub mod pallet {
 			}
 			// Register with parachain registry contract
 			let registry_contract = T::Registry::get();
-			const GAS_LIMIT: u64 = gas_limits::REGISTER;
+			let gas_limit = gas_limit.unwrap_or(gas_limits::REGISTER);
 			let weights = Weights {
 				report_stake_deposited: T::WeightInfo::report_stake_deposited().ref_time(),
 				report_staking_withdraw_request: T::WeightInfo::report_staking_withdraw_request()
@@ -641,9 +641,9 @@ pub mod pallet {
 					)
 					.try_into()
 					.map_err(|_| Error::<T>::MaxEthereumXcmInputSizeExceeded)?,
-					GAS_LIMIT,
+					gas_limit,
 				),
-				GAS_LIMIT,
+				gas_limit,
 			)?;
 			Self::send_xcm(
 				registry_contract.para_id,

--- a/src/tests/governance.rs
+++ b/src/tests/governance.rs
@@ -580,7 +580,7 @@ fn execute_vote() {
 
 	// Prerequisites
 	ext.execute_with(|| {
-		assert_ok!(Tellor::register(RuntimeOrigin::root()));
+		assert_ok!(Tellor::register(RuntimeOrigin::root(), None));
 		with_block(|| deposit_stake(dispute_reporter, MINIMUM_STAKE_AMOUNT, Address::random()))
 	});
 
@@ -1576,7 +1576,7 @@ fn get_vote_count() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	assert_ok!(ext.execute_with(|| with_block(|| Tellor::register(RuntimeOrigin::root()))));
+	assert_ok!(ext.execute_with(|| with_block(|| Tellor::register(RuntimeOrigin::root(), None))));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L298
 	ext.execute_with(|| {
@@ -1648,7 +1648,7 @@ fn get_vote_info() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	assert_ok!(ext.execute_with(|| with_block(|| Tellor::register(RuntimeOrigin::root()))));
+	assert_ok!(ext.execute_with(|| with_block(|| Tellor::register(RuntimeOrigin::root(), None))));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L322
 	ext.execute_with(|| {
@@ -1867,7 +1867,7 @@ fn get_tips_by_address() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	assert_ok!(ext.execute_with(|| with_block(|| Tellor::register(RuntimeOrigin::root()))));
+	assert_ok!(ext.execute_with(|| with_block(|| Tellor::register(RuntimeOrigin::root(), None))));
 
 	// Based on https://github.com/tellor-io/governance/blob/0dcc2ad501b1e51383a99a22c60eeb8c36d61bc3/test/functionTests.js#L404
 	ext.execute_with(|| {
@@ -1941,7 +1941,7 @@ fn invalid_dispute() {
 	// Prerequisites
 	ext.execute_with(|| {
 		with_block(|| {
-			assert_ok!(Tellor::register(RuntimeOrigin::root()));
+			assert_ok!(Tellor::register(RuntimeOrigin::root(), None));
 			deposit_stake(reporter, MINIMUM_STAKE_AMOUNT, Address::random());
 		})
 	});
@@ -1987,7 +1987,7 @@ fn slash_dispute_initiator() {
 	let mut ext = new_test_ext();
 
 	// Prerequisites
-	assert_ok!(ext.execute_with(|| with_block(|| Tellor::register(RuntimeOrigin::root()))));
+	assert_ok!(ext.execute_with(|| with_block(|| Tellor::register(RuntimeOrigin::root(), None))));
 
 	ext.execute_with(|| {
 		Balances::set_balance(&another_reporter, token(1_000));

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -233,7 +233,7 @@ fn registers() {
 			for origin in
 				vec![RuntimeOrigin::signed(0), Origin::Governance.into(), Origin::Staking.into()]
 			{
-				assert_noop!(Tellor::register(origin), BadOrigin);
+				assert_noop!(Tellor::register(origin, None), BadOrigin);
 			}
 
 			let weights = Weights {
@@ -253,7 +253,8 @@ fn registers() {
 				report_slash: <Test as crate::Config>::WeightInfo::report_slash().ref_time(),
 			};
 
-			assert_ok!(Tellor::register(RuntimeOrigin::root()));
+			let gas_limit = 42;
+			assert_ok!(Tellor::register(RuntimeOrigin::root(), Some(gas_limit)));
 			assert_eq!(
 				sent_xcm(),
 				vec![xcm_transact(
@@ -269,10 +270,10 @@ fn registers() {
 						)
 						.try_into()
 						.unwrap(),
-						gas_limits::REGISTER
+						gas_limit
 					)
 					.into(),
-					gas_limits::REGISTER
+					gas_limit
 				)]
 			);
 			System::assert_last_event(

--- a/src/xcm/mod.rs
+++ b/src/xcm/mod.rs
@@ -133,7 +133,7 @@ impl From<ContractLocation> for MultiLocation {
 /// # Returns
 /// A XCM message for remote transact.
 pub(crate) fn transact<T: Config>(
-	dest: impl Into<MultiLocation> + sp_std::marker::Copy,
+	dest: impl Into<MultiLocation> + Copy,
 	call: Vec<u8>,
 	gas_limit: u64,
 ) -> Result<Xcm<()>, DispatchError> {
@@ -282,8 +282,7 @@ mod tests {
 	#[test]
 	fn transact() {
 		const GAS_LIMIT: u64 = 100_000;
-		let xt_weight =
-			<Test as crate::Config>::Weigher::transact(Parachain(EVM_PARA_ID), GAS_LIMIT);
+		let xt_weight = <Test as Config>::Weigher::transact(Parachain(EVM_PARA_ID), GAS_LIMIT);
 
 		let descend_origin = Weight::from_parts(5_992_000, 0);
 		let withdraw_asset = Weight::from_parts(200_000_000, 0);


### PR DESCRIPTION
Allows permissioned caller to optionally override the gas limit used when calling the registry contract, should the gas amount required on the destination chain increase beyond the pallet default.